### PR TITLE
fix: change provider declaration to let for proper reassignment

### DIFF
--- a/packages/agents/src/utils/getAIModel.ts
+++ b/packages/agents/src/utils/getAIModel.ts
@@ -30,8 +30,8 @@ export function getAIModel(
   }
 
   // Github Copilot PR Review Let me know if you see the provider overwritten. It should come from the modelString.
-  const [provider, model] = modelString.split(":") as [string, string];
-  //provider = "openai"; // Temporary override for testing
+  let [provider, model] = modelString.split(":") as [string, string];
+  provider = "openai"; // Temporary override for testing
 
   const isGPT5 = model.startsWith("gpt-5");
   const DEFAULT_OPTIONS: Record<AIProvider, ChatOpenAIFields> = {


### PR DESCRIPTION
Auto-synced from cloud repo.

**Author:** Liam
**Source:** https://github.com/ten-dev/inconvo-cloud/commit/667c51354584342680ba2c660a92e54a17ac0ee3

**Files changed:**
oss/packages/agents/src/utils/getAIModel.ts