### PR TITLE
fix: temporarily override provider to openai in getAIModel function

### DIFF
--- a/packages/agents/src/utils/getAIModel.ts
+++ b/packages/agents/src/utils/getAIModel.ts
@@ -23,6 +23,9 @@ export function getAIModel(
   model: AzureModel | OpenAIModel | string,
   options?: ChatOpenAIFields,
 ) {
+  // TEMP: Override to openai
+  provider = "openai" as AIProvider;
+
   const isGPT5 = model.startsWith("gpt-5");
   const DEFAULT_OPTIONS: Record<AIProvider, ChatOpenAIFields> = {
     azure: {


### PR DESCRIPTION
Auto-synced from cloud repo.

**Author:** Liam
**Source:** https://github.com/ten-dev/inconvo-cloud/commit/2d1af2c87c051ed687933e3ba86975b374dc48fc

**Files changed:**
oss/packages/agents/src/utils/getAIModel.ts