### PR TITLE
Ensure table names are schema prefix for multi schema db connections and fix message filtering logic

### DIFF
--- a/apps/dev-server/prisma.config.ts
+++ b/apps/dev-server/prisma.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from "prisma/config";
 
 // Try to load dotenv (not available in production Docker image)
 try {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
   require("dotenv/config");
 } catch {
   // dotenv not available, env vars should already be set
@@ -10,7 +11,7 @@ try {
 
 // Allow overriding the database path via env var (used by CLI to persist across versions)
 const dbPath =
-  process.env.INCONVO_LOCAL_DB_PATH ||
+  process.env.INCONVO_LOCAL_DB_PATH ??
   path.join(process.cwd(), "prisma", ".inconvo.db");
 
 export default defineConfig({

--- a/apps/dev-server/prisma/migrations/20260130113221_add_schema_to_table/migration.sql
+++ b/apps/dev-server/prisma/migrations/20260130113221_add_schema_to_table/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Table" ADD COLUMN "schema" TEXT;

--- a/apps/dev-server/prisma/schema.prisma
+++ b/apps/dev-server/prisma/schema.prisma
@@ -10,6 +10,7 @@ datasource db {
 model Table {
   id                String             @id @default(uuid())
   name              String             @unique
+  schema            String?            // Database schema name (e.g., 'public', 'sales')
   access            String             @default("OFF")
   context           String?
   createdAt         DateTime           @default(now())

--- a/apps/dev-server/src/app/api/v1/agents/[agentId]/conversations/[conversation_id]/response/route.ts
+++ b/apps/dev-server/src/app/api/v1/agents/[agentId]/conversations/[conversation_id]/response/route.ts
@@ -14,11 +14,6 @@ import type { InconvoResponse } from "@repo/types";
 import { DEV_AGENT_ID, DEV_ORGANISATION_ID } from "~/lib/constants";
 import { corsHeaders, handleOptions } from "~/lib/cors";
 
-interface ResponseCreateParams {
-  message: string;
-  stream?: boolean;
-}
-
 interface SDKResponse {
   id: string;
   conversationId: string;

--- a/apps/dev-server/src/components/ChatInterface.tsx
+++ b/apps/dev-server/src/components/ChatInterface.tsx
@@ -227,9 +227,6 @@ export function ChatInterface() {
       setIsLoading(true);
       setProgressMessage(undefined);
 
-      // Check if this is the first message
-      const isFirstMessage = messages.length === 0;
-
       // Add user message immediately
       const userMessageId = `user-${Date.now()}`;
       setMessages((prev) => [
@@ -307,7 +304,7 @@ export function ChatInterface() {
         setProgressMessage(undefined);
       }
     },
-    [activeConversationId],
+    [activeConversationId, setMessages],
   );
 
   // Count active context values

--- a/apps/dev-server/src/lib/apiParams.ts
+++ b/apps/dev-server/src/lib/apiParams.ts
@@ -18,8 +18,8 @@ export function parseListParams(searchParams: URLSearchParams) {
   // Parse userContext parameters (e.g., userContext[orgId]=123)
   const userContext: Record<string, string | number> = {};
   for (const [key, value] of searchParams.entries()) {
-    const match = key.match(/^userContext\[(.+)\]$/);
-    if (match && match[1]) {
+    const match = /^userContext\[(.+)\]$/.exec(key);
+    if (match?.[1]) {
       const contextKey = match[1];
       // Try to parse as number, otherwise keep as string
       const numValue = Number(value);

--- a/apps/dev-server/src/lib/prisma.ts
+++ b/apps/dev-server/src/lib/prisma.ts
@@ -10,7 +10,7 @@ declare global {
 function createPrismaClient(): PrismaClient {
   // Use INCONVO_LOCAL_DB_PATH if set (Docker), otherwise default to local prisma dir
   const dbPath =
-    process.env.INCONVO_LOCAL_DB_PATH ||
+    process.env.INCONVO_LOCAL_DB_PATH ??
     path.join(process.cwd(), "prisma", ".inconvo.db");
   const adapter = new PrismaBetterSqlite3({ url: dbPath });
   return new PrismaClient({ adapter });

--- a/apps/sandbox/package.json
+++ b/apps/sandbox/package.json
@@ -24,6 +24,6 @@
     "@types/node": "catalog:",
     "eslint": "catalog:",
     "typescript": "catalog:",
-    "wrangler": "^4.59.3"
+    "wrangler": "catalog:"
   }
 }

--- a/packages/agents/src/database/index.ts
+++ b/packages/agents/src/database/index.ts
@@ -305,6 +305,7 @@ export async function databaseRetrieverAgent(params: RequestParams) {
   const buildQuery = async (state: typeof DatabaseAgentState.State) => {
     const query: DBQuery = {
       table: state.tableName,
+      tableSchema: state.tableSchema.schema ?? null,  // Include schema from selected table
       operation: state.operation,
       operationParameters: state.operationParams,
       tableConditions: null, // Set below after building tableConditionsMap

--- a/packages/agents/src/database/questionWhere/schemaValidator.stubSchema.ts
+++ b/packages/agents/src/database/questionWhere/schemaValidator.stubSchema.ts
@@ -3,6 +3,7 @@ import type { Schema } from "@repo/types";
 export const stubSchema = [
   {
     name: "User",
+    schema: null,
     access: "QUERYABLE",
     context: null,
     columns: [
@@ -77,6 +78,7 @@ export const stubSchema = [
         name: "profile",
         relationId: "User_profile",
         targetTable: { name: "Profile" },
+        targetSchema: null,
         isList: false,
         selected: true,
         source: "FK",
@@ -89,6 +91,7 @@ export const stubSchema = [
         name: "posts",
         relationId: "User_posts",
         targetTable: { name: "Post" },
+        targetSchema: null,
         isList: true,
         selected: true,
         source: "FK",
@@ -102,6 +105,7 @@ export const stubSchema = [
   },
   {
     name: "Profile",
+    schema: null,
     access: "QUERYABLE",
     context: null,
     columns: [
@@ -156,6 +160,7 @@ export const stubSchema = [
   },
   {
     name: "Post",
+    schema: null,
     access: "QUERYABLE",
     context: null,
     columns: [

--- a/packages/agents/src/database/types.ts
+++ b/packages/agents/src/database/types.ts
@@ -12,6 +12,7 @@ export type Operation =
 
 export interface DBQuery {
   table: string;
+  tableSchema?: string | null;  // Database schema name (e.g., 'public', 'sales')
   operation: string;
   operationParameters: Record<string, unknown>;
   whereAndArray?: WhereAndArray;

--- a/packages/agents/src/database/utils/schemaFormatters.ts
+++ b/packages/agents/src/database/utils/schemaFormatters.ts
@@ -33,6 +33,11 @@ export function stringifyComputedColumnAst(
 export function buildTableSchemaStringFromTableSchema(
   tableSchema: TableSchema,
 ) {
+  // Include schema prefix when present (e.g., "public.users" or "sales.orders")
+  const tableName = tableSchema.schema
+    ? `${tableSchema.schema}.${tableSchema.name}`
+    : tableSchema.name;
+
   const access =
     tableSchema.access === "QUERYABLE"
       ? `Access: Selectable`
@@ -69,7 +74,11 @@ export function buildTableSchemaStringFromTableSchema(
     tableSchema.outwardRelations.length > 0
       ? tableSchema.outwardRelations
           .map((relation) => {
-            return `\t\t- ${relation.name} (${relation.targetTable.name}${
+            // Include target schema for cross-schema relations
+            const targetDisplay = relation.targetSchema
+              ? `${relation.targetSchema}.${relation.targetTable.name}`
+              : relation.targetTable.name;
+            return `\t\t- ${relation.name} (${targetDisplay}${
               relation.isList ? "[]" : ""
             })`;
           })
@@ -80,7 +89,7 @@ export function buildTableSchemaStringFromTableSchema(
     ? `\n\t<${tableSchema.name}TableContext>\n${tableSchema.context}\n\t</${tableSchema.name}TableContext>`
     : "";
 
-  return `${tableSchema.name}\n\t${access}\n${columns}${computedColumns}${relations}${context}`;
+  return `${tableName}\n\t${access}\n${columns}${computedColumns}${relations}${context}`;
 }
 
 function buildTableSchemaString(schema: Schema, table: string) {

--- a/packages/agents/src/inconvo/index.ts
+++ b/packages/agents/src/inconvo/index.ts
@@ -299,25 +299,42 @@ export async function inconvoAgent(params: QuestionAgentParams) {
             ),
           );
 
-          // 4. Filter out old databaseRetriever messages, keeping the last N
-          const filteredHistory = x.filter((msg) => {
-            // Remove only tool messages whose tool_call_id is in the removal set
-            if (ToolMessage.isInstance(msg) && msg.tool_call_id) {
-              if (idsToRemove.has(msg.tool_call_id)) return false;
-            }
-            // Remove AI messages that contain databaseRetriever tool calls to be removed
+          // 4. First pass: identify AI messages to remove and collect ALL their tool call IDs
+          const allToolCallIdsToRemove = new Set<string>();
+          const aiMessagesToRemove = new Set<BaseMessage>();
+
+          x.forEach((msg) => {
             if (AIMessage.isInstance(msg)) {
-              const dbCalls = [
+              const allCalls = [
                 ...(msg.tool_calls ?? []),
                 ...(msg.invalid_tool_calls ?? []),
-              ].filter((c) => c.name === "databaseRetriever" && c.id);
+              ];
+              const dbCalls = allCalls.filter(
+                (c) => c.name === "databaseRetriever" && c.id,
+              );
               // If all db calls in this message are in the removal set, remove the message
               if (
                 dbCalls.length > 0 &&
                 dbCalls.every((c) => c.id && idsToRemove.has(c.id))
               ) {
-                return false;
+                aiMessagesToRemove.add(msg);
+                // Collect ALL tool call IDs from this message (not just databaseRetriever)
+                allCalls.forEach((c) => {
+                  if (c.id) allToolCallIdsToRemove.add(c.id);
+                });
               }
+            }
+          });
+
+          // 5. Filter out AI messages and their corresponding ToolMessages
+          const filteredHistory = x.filter((msg) => {
+            // Remove tool messages whose tool_call_id belongs to a removed AI message
+            if (ToolMessage.isInstance(msg) && msg.tool_call_id) {
+              if (allToolCallIdsToRemove.has(msg.tool_call_id)) return false;
+            }
+            // Remove marked AI messages
+            if (aiMessagesToRemove.has(msg)) {
+              return false;
             }
             return true;
           });

--- a/packages/agents/src/utils/getAIModel.ts
+++ b/packages/agents/src/utils/getAIModel.ts
@@ -23,6 +23,9 @@ export function getAIModel(
   model: AzureModel | OpenAIModel | string,
   options?: ChatOpenAIFields,
 ) {
+  // TEMP: Override to openai
+  provider = "openai" as AIProvider;
+
   const isGPT5 = model.startsWith("gpt-5");
   const DEFAULT_OPTIONS: Record<AIProvider, ChatOpenAIFields> = {
     azure: {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -33,7 +33,7 @@
     "kysely": "catalog:",
     "mysql2": "^3.16.1",
     "pg": "catalog:",
-    "yaml": "^2.7.0"
+    "yaml": "catalog:"
   },
   "devDependencies": {
     "@repo/eslint-config": "workspace:*",

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -40,10 +40,10 @@
     "kysely": "catalog:",
     "mysql2": "^3.15.1",
     "pg": "catalog:",
-    "pino": "^9.9.0",
+    "pino": "^10.3.0",
     "pino-pretty": "^13.1.1",
     "tarn": "^3.0.2",
-    "tedious": "^18.0.0",
+    "tedious": "^19.2.0",
     "typescript": "catalog:",
     "zod": "catalog:"
   },

--- a/packages/connect/src/express/index.ts
+++ b/packages/connect/src/express/index.ts
@@ -94,10 +94,8 @@ export async function inconvo(): Promise<Router> {
       clearSchemaCache();
       clearAugmentedSchemaCache();
       const schema = await getCachedSchema();
-      const { databaseSchema: _databaseSchema } = schema;
       const sanitizedTables = schema.tables.map(
         ({
-          schema: _tableSchema,
           computedColumns: _computedColumns,
           columnConversions: _columnConversions,
           ...table
@@ -116,6 +114,7 @@ export async function inconvo(): Promise<Router> {
       );
       const publicSchema = {
         tables: sanitizedTables,
+        databaseSchema: schema.databaseSchema,
       };
       res.setHeader("Content-Type", "application/json");
       res.send(safeJsonStringify(publicSchema));

--- a/packages/connect/src/operations/aggregate/index.ts
+++ b/packages/connect/src/operations/aggregate/index.ts
@@ -5,6 +5,7 @@ import type { DatabaseDialect, OperationContext } from "../types";
 import { buildWhereConditions } from "../utils/whereConditionBuilder";
 import { getColumnFromTable } from "../utils/computedColumns";
 import { buildJsonObject } from "../utils/jsonBuilderHelpers";
+import { getTableIdentifier } from "../utils/tableIdentifier";
 import assert from "assert";
 import {
   applyJoinHop,
@@ -96,7 +97,9 @@ export async function aggregate(
     selectFields.push(buildJsonObject(medianFields, dialect).as("_median"));
   }
 
-  let dbQuery = db.selectFrom(table);
+  // Build query with schema-qualified table name
+  const tableId = getTableIdentifier(table, query.tableSchema, dialect);
+  let dbQuery = db.selectFrom(tableId);
 
   const resolvedJoins =
     (operationParameters.joins ?? []).map((join) =>
@@ -126,7 +129,7 @@ export async function aggregate(
         continue; // Skip duplicate hop
       }
       appliedHops.add(hopKey);
-      dbQuery = applyJoinHop(dbQuery, joinDescriptor.joinType, hop);
+      dbQuery = applyJoinHop(dbQuery, joinDescriptor.joinType, hop, schema, dialect);
     }
   }
 

--- a/packages/connect/src/operations/count/index.ts
+++ b/packages/connect/src/operations/count/index.ts
@@ -4,6 +4,7 @@ import type { OperationContext } from "../types";
 import { buildWhereConditions } from "../utils/whereConditionBuilder";
 import { getColumnFromTable } from "../utils/computedColumns";
 import { getSchemaBoundDb } from "../utils/schemaHelpers";
+import { getTableIdentifier } from "../utils/tableIdentifier";
 import assert from "assert";
 import {
   applyJoinHop,
@@ -24,7 +25,9 @@ export async function count(
 
   const dbForQuery = getSchemaBoundDb(db, schema, dialect);
 
-  let dbQuery = dbForQuery.selectFrom(table);
+  // Build query with schema-qualified table name
+  const tableId = getTableIdentifier(table, query.tableSchema, dialect);
+  let dbQuery = dbForQuery.selectFrom(tableId);
 
   const resolvedJoins =
     (joins ?? []).map((join) =>
@@ -61,7 +64,7 @@ export async function count(
         continue; // Skip duplicate hop
       }
       appliedHops.add(hopKey);
-      dbQuery = applyJoinHop(dbQuery, joinDescriptor.joinType, hop);
+      dbQuery = applyJoinHop(dbQuery, joinDescriptor.joinType, hop, schema, dialect);
     }
   }
 

--- a/packages/connect/src/operations/countRelations/index.ts
+++ b/packages/connect/src/operations/countRelations/index.ts
@@ -3,6 +3,7 @@ import type { Query } from "../../types/querySchema";
 import { buildWhereConditions } from "../utils/whereConditionBuilder";
 import { getColumnFromTable } from "../utils/computedColumns";
 import { applyLimit } from "../utils/queryHelpers";
+import { getTableIdentifier } from "../utils/tableIdentifier";
 import assert from "assert";
 import {
   normaliseJoinHop,
@@ -138,7 +139,9 @@ export async function countRelations(
     builder = builder.with(plan.cteName, () => plan.cteQuery);
   }
 
-  let selectBuilder = builder.selectFrom(table);
+  // Build query with schema-qualified table name
+  const tableId = getTableIdentifier(table, query.tableSchema, dialect);
+  let selectBuilder = builder.selectFrom(tableId);
 
   const baseSelections: any[] = [];
   for (const column of columns ?? []) {

--- a/packages/connect/src/operations/findDistinct/index.ts
+++ b/packages/connect/src/operations/findDistinct/index.ts
@@ -4,6 +4,7 @@ import { buildWhereConditions } from "../utils/whereConditionBuilder";
 import { getColumnFromTable } from "../utils/computedColumns";
 import { applyLimit } from "../utils/queryHelpers";
 import { getSchemaBoundDb } from "../utils/schemaHelpers";
+import { getTableIdentifier } from "../utils/tableIdentifier";
 import { executeWithLogging } from "../utils/executeWithLogging";
 import type { OperationContext } from "../types";
 import assert from "assert";
@@ -31,8 +32,10 @@ export async function findDistinct(
     dialect,
   });
 
+  // Build query with schema-qualified table name
+  const tableId = getTableIdentifier(table, query.tableSchema, dialect);
   let dbQuery = dbForQuery
-    .selectFrom(table)
+    .selectFrom(tableId)
     .select(distinctColumn.as(operationParameters.column))
     .distinct();
 

--- a/packages/connect/src/operations/findDistinctByEditDistance/index.ts
+++ b/packages/connect/src/operations/findDistinctByEditDistance/index.ts
@@ -4,6 +4,7 @@ import { buildWhereConditions } from "../utils/whereConditionBuilder";
 import { getColumnFromTable } from "../utils/computedColumns";
 import { applyLimit } from "../utils/queryHelpers";
 import { getSchemaBoundDb } from "../utils/schemaHelpers";
+import { getTableIdentifier } from "../utils/tableIdentifier";
 import { executeWithLogging } from "../utils/executeWithLogging";
 import type { OperationContext } from "../types";
 import levenshtein from "fast-levenshtein";
@@ -47,8 +48,10 @@ export async function findDistinctByEditDistance(
     dialect,
   });
 
+  // Build query with schema-qualified table name
+  const tableId = getTableIdentifier(table, query.tableSchema, dialect);
   let dbQuery = dbForQuery
-    .selectFrom(table)
+    .selectFrom(tableId)
     .select(distinctColumn.as(operationParameters.column))
     .distinct();
 

--- a/packages/connect/src/operations/groupBy/index.ts
+++ b/packages/connect/src/operations/groupBy/index.ts
@@ -12,6 +12,7 @@ import {
 import { createAggregationFields } from "../utils/createAggregationFields";
 import { applyLimit } from "../utils/queryHelpers";
 import { getSchemaBoundDb } from "../utils/schemaHelpers";
+import { getTableIdentifier } from "../utils/tableIdentifier";
 import { buildDateIntervalExpression } from "../utils/buildDateIntervalExpression";
 import { buildDateComponentExpressions } from "../utils/buildDateComponentExpression";
 import assert from "assert";
@@ -35,7 +36,9 @@ export async function groupBy(
   const { groupBy: groupByList, orderBy, limit, joins } = operationParameters;
   const having = operationParameters.having ?? null;
 
-  let dbQuery = dbForQuery.selectFrom(table);
+  // Build query with schema-qualified table name
+  const tableId = getTableIdentifier(table, query.tableSchema, dialect);
+  let dbQuery = dbForQuery.selectFrom(tableId);
 
   // Handle joins if specified - deduplicate hops to avoid duplicate table joins
   if (joins && joins.length > 0) {
@@ -50,7 +53,7 @@ export async function groupBy(
         }
         appliedHops.add(hopKey);
         const metadata = normaliseJoinHop(hop);
-        dbQuery = applyJoinHop(dbQuery, joinType, metadata);
+        dbQuery = applyJoinHop(dbQuery, joinType, metadata, schema, dialect);
       }
     }
   }

--- a/packages/connect/src/operations/utils/tableIdentifier.ts
+++ b/packages/connect/src/operations/utils/tableIdentifier.ts
@@ -1,0 +1,26 @@
+import type { DatabaseDialect } from "../../types/types";
+
+/**
+ * Get a schema-qualified table identifier for SQL queries.
+ * When tableSchema is provided, returns "schema.table" format.
+ * When tableSchema is null/undefined, returns just the table name.
+ *
+ * All supported dialects (PostgreSQL, Redshift, MySQL, MS SQL, BigQuery)
+ * use the same schema.table format.
+ *
+ * @param tableName - The table name
+ * @param tableSchema - The schema name (optional)
+ * @param _dialect - The database dialect (currently unused but available for future dialect-specific handling)
+ * @returns The schema-qualified table identifier
+ */
+export function getTableIdentifier(
+  tableName: string,
+  tableSchema: string | null | undefined,
+  _dialect: DatabaseDialect,
+): string {
+  if (!tableSchema) {
+    return tableName;
+  }
+  // All supported dialects use schema.table format
+  return `${tableSchema}.${tableName}`;
+}

--- a/packages/connect/src/types/querySchema.ts
+++ b/packages/connect/src/types/querySchema.ts
@@ -233,6 +233,7 @@ export type TableConditionsMap = z.infer<typeof tableConditionsMapSchema>;
 
 const baseSchema = {
   table: z.string(),
+  tableSchema: z.string().nullable().optional(),  // Database schema name (e.g., 'public', 'sales')
   whereAndArray: whereAndArraySchema,
   tableConditions: tableConditionsMapSchema,
 };

--- a/packages/connect/src/types/types.d.ts
+++ b/packages/connect/src/types/types.d.ts
@@ -30,6 +30,7 @@ export interface SchemaRelation {
   name: string;
   isList: boolean;
   targetTable: string;
+  targetSchema?: string;  // For cross-schema relations
   sourceColumns?: string[];
   targetColumns?: string[];
   source?: "FK" | "MANUAL";

--- a/packages/connect/test/mssql/multiSchema.test.ts
+++ b/packages/connect/test/mssql/multiSchema.test.ts
@@ -1,0 +1,538 @@
+// @ts-nocheck
+/**
+ * Multi-Schema Tests for MSSQL
+ *
+ * Tests schema-qualified table names when querying tables in different schemas.
+ * Requires the demo database with both `dbo` and `hr` schemas.
+ */
+import { sql } from "kysely";
+import type { Kysely } from "kysely";
+import { loadTestEnv, getTestContext } from "../loadTestEnv";
+import type { SchemaResponse } from "../../src/types/types";
+import type { OperationContext } from "../../src/operations/types";
+
+describe("MSSQL Multi-Schema Operations", () => {
+  let db: Kysely<any>;
+  let QuerySchema: (typeof import("~/types/querySchema"))["QuerySchema"];
+  let findMany: (typeof import("~/operations/findMany"))["findMany"];
+  let count: (typeof import("~/operations/count"))["count"];
+  let groupBy: (typeof import("~/operations/groupBy"))["groupBy"];
+  let aggregate: (typeof import("~/operations/aggregate"))["aggregate"];
+  let clearSchemaCache: (typeof import("~/util/schemaCache"))["clearSchemaCache"];
+
+  // Custom context with HR schema tables
+  let hrCtx: OperationContext;
+  let dboCtx: OperationContext;
+
+  // Helper to check if SQL contains schema-qualified table reference
+  // MSSQL quotes identifiers, so "hr"."employees" is valid
+  const containsSchemaTable = (sqlStr: string, schema: string, table: string) => {
+    return (
+      sqlStr.includes(`${schema}.${table}`) ||
+      sqlStr.includes(`"${schema}"."${table}"`) ||
+      sqlStr.includes(`"${schema}".${table}`) ||
+      sqlStr.includes(`${schema}."${table}"`) ||
+      sqlStr.includes(`[${schema}].[${table}]`)
+    );
+  };
+
+  beforeAll(async () => {
+    loadTestEnv("mssql");
+
+    jest.resetModules();
+    delete (globalThis as any).__INCONVO_KYSELY_DB__;
+
+    ({ clearSchemaCache } = await import("~/util/schemaCache"));
+    await clearSchemaCache();
+
+    QuerySchema = (await import("~/types/querySchema")).QuerySchema;
+    findMany = (await import("~/operations/findMany")).findMany;
+    count = (await import("~/operations/count")).count;
+    groupBy = (await import("~/operations/groupBy")).groupBy;
+    aggregate = (await import("~/operations/aggregate")).aggregate;
+    const { getDb } = await import("~/dbConnection");
+    db = await getDb();
+
+    // Build HR schema context manually
+    const hrSchema: SchemaResponse = {
+      tables: [
+        {
+          name: "departments",
+          schema: "hr",
+          columns: [
+            { name: "id", type: "number" },
+            { name: "name", type: "string" },
+            { name: "budget", type: "number" },
+            { name: "location", type: "string" },
+            { name: "created_at", type: "DateTime" },
+          ],
+          relations: [
+            {
+              name: "employees",
+              isList: true,
+              targetTable: "employees",
+              targetSchema: "hr",
+              sourceColumns: ["id"],
+              targetColumns: ["department_id"],
+            },
+          ],
+        },
+        {
+          name: "employees",
+          schema: "hr",
+          columns: [
+            { name: "id", type: "number" },
+            { name: "department_id", type: "number" },
+            { name: "first_name", type: "string" },
+            { name: "last_name", type: "string" },
+            { name: "email", type: "string" },
+            { name: "hire_date", type: "DateTime" },
+            { name: "salary", type: "number" },
+            { name: "job_title", type: "string" },
+            { name: "manager_id", type: "number" },
+            { name: "is_active", type: "boolean" },
+          ],
+          relations: [
+            {
+              name: "department",
+              isList: false,
+              targetTable: "departments",
+              targetSchema: "hr",
+              sourceColumns: ["department_id"],
+              targetColumns: ["id"],
+            },
+          ],
+        },
+        {
+          name: "projects",
+          schema: "hr",
+          columns: [
+            { name: "id", type: "number" },
+            { name: "name", type: "string" },
+            { name: "department_id", type: "number" },
+            { name: "start_date", type: "DateTime" },
+            { name: "end_date", type: "DateTime" },
+            { name: "status", type: "string" },
+            { name: "budget", type: "number" },
+          ],
+          relations: [],
+        },
+        {
+          name: "project_assignments",
+          schema: "hr",
+          columns: [
+            { name: "id", type: "number" },
+            { name: "project_id", type: "number" },
+            { name: "employee_id", type: "number" },
+            { name: "role", type: "string" },
+            { name: "hours_allocated", type: "number" },
+            { name: "assigned_at", type: "DateTime" },
+          ],
+          relations: [],
+        },
+        {
+          name: "time_entries",
+          schema: "hr",
+          columns: [
+            { name: "id", type: "number" },
+            { name: "employee_id", type: "number" },
+            { name: "project_id", type: "number" },
+            { name: "date", type: "DateTime" },
+            { name: "hours", type: "number" },
+            { name: "description", type: "string" },
+          ],
+          relations: [],
+        },
+      ],
+      databaseSchema: "hr",
+    };
+
+    hrCtx = {
+      schema: hrSchema,
+      dialect: "mssql",
+    };
+
+    // Get dbo schema context using existing test helper
+    dboCtx = await getTestContext();
+  });
+
+  afterAll(async () => {
+    if (db) await db.destroy();
+    await clearSchemaCache?.();
+  });
+
+  describe("findMany with tableSchema", () => {
+    it("queries hr.departments with schema qualification", async () => {
+      const iql = {
+        operation: "findMany" as const,
+        table: "departments",
+        tableSchema: "hr",
+        tableConditions: null,
+        whereAndArray: [],
+        operationParameters: {
+          select: {
+            departments: ["id", "name", "budget", "location"],
+          },
+          orderBy: { column: "id", direction: "asc" as const },
+          limit: 10,
+        },
+      };
+
+      const parsed = QuerySchema.parse(iql);
+      const response = await findMany(db, parsed, hrCtx);
+
+      // Verify the SQL includes schema qualification
+      expect(containsSchemaTable(response.query.sql, "hr", "departments")).toBe(true);
+      expect(response.data).toBeDefined();
+      expect(Array.isArray(response.data)).toBe(true);
+      expect(response.data.length).toBeGreaterThan(0);
+    });
+
+    it("queries hr.employees with schema qualification", async () => {
+      const iql = {
+        operation: "findMany" as const,
+        table: "employees",
+        tableSchema: "hr",
+        tableConditions: null,
+        whereAndArray: [],
+        operationParameters: {
+          select: {
+            employees: ["id", "first_name", "last_name", "salary", "job_title"],
+          },
+          orderBy: { column: "id", direction: "asc" as const },
+          limit: 10,
+        },
+      };
+
+      const parsed = QuerySchema.parse(iql);
+      const response = await findMany(db, parsed, hrCtx);
+
+      expect(containsSchemaTable(response.query.sql, "hr", "employees")).toBe(true);
+      expect(response.data).toBeDefined();
+      expect(response.data.length).toBeGreaterThan(0);
+    });
+
+    it("queries hr.employees with WHERE conditions", async () => {
+      const iql = {
+        operation: "findMany" as const,
+        table: "employees",
+        tableSchema: "hr",
+        tableConditions: null,
+        whereAndArray: [
+          {
+            "employees.salary": { gte: 100000 },
+          },
+        ],
+        operationParameters: {
+          select: {
+            employees: ["id", "first_name", "last_name", "salary"],
+          },
+          orderBy: { column: "salary", direction: "desc" as const },
+          limit: 5,
+        },
+      };
+
+      const parsed = QuerySchema.parse(iql);
+      const response = await findMany(db, parsed, hrCtx);
+
+      expect(containsSchemaTable(response.query.sql, "hr", "employees")).toBe(true);
+      expect(response.data).toBeDefined();
+    });
+
+    it("queries hr.projects with status filter", async () => {
+      const iql = {
+        operation: "findMany" as const,
+        table: "projects",
+        tableSchema: "hr",
+        tableConditions: null,
+        whereAndArray: [
+          {
+            "projects.status": { equals: "active" },
+          },
+        ],
+        operationParameters: {
+          select: {
+            projects: ["id", "name", "status", "budget"],
+          },
+          orderBy: { column: "id", direction: "asc" as const },
+          limit: 10,
+        },
+      };
+
+      const parsed = QuerySchema.parse(iql);
+      const response = await findMany(db, parsed, hrCtx);
+
+      expect(containsSchemaTable(response.query.sql, "hr", "projects")).toBe(true);
+      expect(response.data).toBeDefined();
+    });
+  });
+
+  describe("count with tableSchema", () => {
+    it("counts hr.employees", async () => {
+      const iql = {
+        operation: "count" as const,
+        table: "employees",
+        tableSchema: "hr",
+        tableConditions: null,
+        whereAndArray: [],
+        operationParameters: {
+          count: ["employees.id"],
+        },
+      };
+
+      const parsed = QuerySchema.parse(iql);
+      const response = await count(db, parsed, hrCtx);
+
+      expect(containsSchemaTable(response.query.sql, "hr", "employees")).toBe(true);
+      expect(response.data).toBeDefined();
+      expect(response.data._count).toBeDefined();
+    });
+
+    it("counts hr.departments", async () => {
+      const iql = {
+        operation: "count" as const,
+        table: "departments",
+        tableSchema: "hr",
+        tableConditions: null,
+        whereAndArray: [],
+        operationParameters: {
+          count: ["departments.id"],
+        },
+      };
+
+      const parsed = QuerySchema.parse(iql);
+      const response = await count(db, parsed, hrCtx);
+
+      expect(containsSchemaTable(response.query.sql, "hr", "departments")).toBe(true);
+      expect(response.data._count["departments.id"]).toBe(5);
+    });
+  });
+
+  describe("groupBy with tableSchema", () => {
+    it("groups hr.employees by department", async () => {
+      const iql = {
+        operation: "groupBy" as const,
+        table: "employees",
+        tableSchema: "hr",
+        tableConditions: null,
+        whereAndArray: [],
+        operationParameters: {
+          groupBy: [{ type: "column" as const, column: "employees.department_id" }],
+          count: ["employees.id"],
+          countDistinct: null,
+          sum: null,
+          min: null,
+          max: null,
+          avg: null,
+          orderBy: { type: "aggregate" as const, function: "count" as const, column: "employees.id", direction: "desc" as const },
+          limit: 10,
+        },
+      };
+
+      const parsed = QuerySchema.parse(iql);
+      const response = await groupBy(db, parsed, hrCtx);
+
+      expect(containsSchemaTable(response.query.sql, "hr", "employees")).toBe(true);
+      expect(response.data).toBeDefined();
+      expect(Array.isArray(response.data)).toBe(true);
+    });
+
+    it("groups hr.projects by status with aggregates", async () => {
+      const iql = {
+        operation: "groupBy" as const,
+        table: "projects",
+        tableSchema: "hr",
+        tableConditions: null,
+        whereAndArray: [],
+        operationParameters: {
+          groupBy: [{ type: "column" as const, column: "projects.status" }],
+          count: ["projects.id"],
+          countDistinct: null,
+          sum: ["projects.budget"],
+          min: null,
+          max: null,
+          avg: null,
+          orderBy: { type: "aggregate" as const, function: "count" as const, column: "projects.id", direction: "desc" as const },
+          limit: 10,
+        },
+      };
+
+      const parsed = QuerySchema.parse(iql);
+      const response = await groupBy(db, parsed, hrCtx);
+
+      expect(containsSchemaTable(response.query.sql, "hr", "projects")).toBe(true);
+      expect(response.data).toBeDefined();
+    });
+  });
+
+  describe("aggregate with tableSchema", () => {
+    it("aggregates hr.employees salaries", async () => {
+      const iql = {
+        operation: "aggregate" as const,
+        table: "employees",
+        tableSchema: "hr",
+        tableConditions: null,
+        whereAndArray: [],
+        operationParameters: {
+          sum: ["employees.salary"],
+          avg: ["employees.salary"],
+          min: ["employees.salary"],
+          max: ["employees.salary"],
+          count: ["employees.id"],
+          countDistinct: null,
+          median: null,
+        },
+      };
+
+      const parsed = QuerySchema.parse(iql);
+      const response = await aggregate(db, parsed, hrCtx);
+
+      expect(containsSchemaTable(response.query.sql, "hr", "employees")).toBe(true);
+      expect(response.data).toBeDefined();
+      expect(response.data._sum).toBeDefined();
+      expect(response.data._avg).toBeDefined();
+    });
+
+    it("aggregates hr.projects budgets", async () => {
+      const iql = {
+        operation: "aggregate" as const,
+        table: "projects",
+        tableSchema: "hr",
+        tableConditions: null,
+        whereAndArray: [],
+        operationParameters: {
+          sum: ["projects.budget"],
+          avg: null,
+          min: null,
+          max: null,
+          count: ["projects.id"],
+          countDistinct: null,
+          median: null,
+        },
+      };
+
+      const parsed = QuerySchema.parse(iql);
+      const response = await aggregate(db, parsed, hrCtx);
+
+      expect(containsSchemaTable(response.query.sql, "hr", "projects")).toBe(true);
+      expect(response.data._sum["projects.budget"]).toBeGreaterThan(0);
+    });
+  });
+
+  describe("relation filters with tableSchema", () => {
+    it("filters hr.employees with department relation filter", async () => {
+      const iql = {
+        operation: "findMany" as const,
+        table: "employees",
+        tableSchema: "hr",
+        tableConditions: null,
+        whereAndArray: [
+          {
+            AND: [
+              {
+                department: {
+                  is: {
+                    name: { equals: "Engineering" },
+                  },
+                },
+              },
+            ],
+          },
+        ],
+        operationParameters: {
+          select: {
+            employees: ["id", "first_name", "last_name", "job_title"],
+          },
+          orderBy: { column: "id", direction: "asc" as const },
+          limit: 10,
+        },
+      };
+
+      const parsed = QuerySchema.parse(iql);
+      const response = await findMany(db, parsed, hrCtx);
+
+      // Should use schema-qualified names for both tables
+      expect(containsSchemaTable(response.query.sql, "hr", "employees")).toBe(true);
+      expect(containsSchemaTable(response.query.sql, "hr", "departments")).toBe(true);
+      expect(response.data).toBeDefined();
+    });
+
+    it("filters hr.departments with employees some filter", async () => {
+      const iql = {
+        operation: "findMany" as const,
+        table: "departments",
+        tableSchema: "hr",
+        tableConditions: null,
+        whereAndArray: [
+          {
+            AND: [
+              {
+                employees: {
+                  some: {
+                    salary: { gte: 150000 },
+                  },
+                },
+              },
+            ],
+          },
+        ],
+        operationParameters: {
+          select: {
+            departments: ["id", "name"],
+          },
+          orderBy: { column: "id", direction: "asc" as const },
+          limit: 10,
+        },
+      };
+
+      const parsed = QuerySchema.parse(iql);
+      const response = await findMany(db, parsed, hrCtx);
+
+      expect(containsSchemaTable(response.query.sql, "hr", "departments")).toBe(true);
+      expect(containsSchemaTable(response.query.sql, "hr", "employees")).toBe(true);
+      expect(response.data).toBeDefined();
+    });
+  });
+
+  describe("verify schema isolation", () => {
+    it("dbo.users and hr.employees are separate tables", async () => {
+      // Query dbo schema users
+      const dboQuery = {
+        operation: "count" as const,
+        table: "users",
+        tableConditions: null,
+        whereAndArray: [],
+        operationParameters: {
+          count: ["users.id"],
+        },
+      };
+
+      // Query hr schema employees
+      const hrQuery = {
+        operation: "count" as const,
+        table: "employees",
+        tableSchema: "hr",
+        tableConditions: null,
+        whereAndArray: [],
+        operationParameters: {
+          count: ["employees.id"],
+        },
+      };
+
+      const dboParsed = QuerySchema.parse(dboQuery);
+      const hrParsed = QuerySchema.parse(hrQuery);
+
+      const dboResponse = await count(db, dboParsed, dboCtx);
+      const hrResponse = await count(db, hrParsed, hrCtx);
+
+      // DBO should NOT contain hr schema qualification
+      expect(containsSchemaTable(dboResponse.query.sql, "hr", "users")).toBe(false);
+      // HR should contain hr schema qualification
+      expect(containsSchemaTable(hrResponse.query.sql, "hr", "employees")).toBe(true);
+
+      // Both should have data
+      expect(dboResponse.data._count["users.id"]).toBeGreaterThan(0);
+      expect(hrResponse.data._count["employees.id"]).toBe(12);
+    });
+  });
+});

--- a/packages/connect/test/mysql/multiSchema.test.ts
+++ b/packages/connect/test/mysql/multiSchema.test.ts
@@ -1,0 +1,384 @@
+// @ts-nocheck
+/**
+ * Multi-Schema Tests for MySQL
+ *
+ * MySQL uses separate databases instead of schemas.
+ * Tests schema-qualified table names when querying tables in different databases.
+ * Requires the demo database with both `hosted` and `hr` databases.
+ */
+import { sql } from "kysely";
+import type { Kysely } from "kysely";
+import { loadTestEnv, getTestContext } from "../loadTestEnv";
+import type { SchemaResponse } from "../../src/types/types";
+import type { OperationContext } from "../../src/operations/types";
+
+describe("MySQL Multi-Schema Operations", () => {
+  let db: Kysely<any>;
+  let QuerySchema: (typeof import("~/types/querySchema"))["QuerySchema"];
+  let findMany: (typeof import("~/operations/findMany"))["findMany"];
+  let count: (typeof import("~/operations/count"))["count"];
+  let groupBy: (typeof import("~/operations/groupBy"))["groupBy"];
+  let aggregate: (typeof import("~/operations/aggregate"))["aggregate"];
+  let clearSchemaCache: (typeof import("~/util/schemaCache"))["clearSchemaCache"];
+
+  // Custom context with HR database tables
+  let hrCtx: OperationContext;
+  let publicCtx: OperationContext;
+
+  // Helper to check if SQL contains schema-qualified table reference
+  // MySQL uses backticks for identifiers, so `hr`.`employees` is valid
+  const containsSchemaTable = (sqlStr: string, schema: string, table: string) => {
+    return (
+      sqlStr.includes(`${schema}.${table}`) ||
+      sqlStr.includes(`\`${schema}\`.\`${table}\``) ||
+      sqlStr.includes(`\`${schema}\`.${table}`) ||
+      sqlStr.includes(`${schema}.\`${table}\``)
+    );
+  };
+
+  beforeAll(async () => {
+    loadTestEnv("mysql");
+
+    jest.resetModules();
+    delete (globalThis as any).__INCONVO_KYSELY_DB__;
+
+    ({ clearSchemaCache } = await import("~/util/schemaCache"));
+    await clearSchemaCache();
+
+    QuerySchema = (await import("~/types/querySchema")).QuerySchema;
+    findMany = (await import("~/operations/findMany")).findMany;
+    count = (await import("~/operations/count")).count;
+    groupBy = (await import("~/operations/groupBy")).groupBy;
+    aggregate = (await import("~/operations/aggregate")).aggregate;
+    const { getDb } = await import("~/dbConnection");
+    db = await getDb();
+
+    // Build HR schema context manually (MySQL uses database name as schema)
+    const hrSchema: SchemaResponse = {
+      tables: [
+        {
+          name: "departments",
+          schema: "hr",
+          columns: [
+            { name: "id", type: "number" },
+            { name: "name", type: "string" },
+            { name: "budget", type: "number" },
+            { name: "location", type: "string" },
+            { name: "created_at", type: "DateTime" },
+          ],
+          relations: [
+            {
+              name: "employees",
+              isList: true,
+              targetTable: "employees",
+              targetSchema: "hr",
+              sourceColumns: ["id"],
+              targetColumns: ["department_id"],
+            },
+          ],
+        },
+        {
+          name: "employees",
+          schema: "hr",
+          columns: [
+            { name: "id", type: "number" },
+            { name: "department_id", type: "number" },
+            { name: "first_name", type: "string" },
+            { name: "last_name", type: "string" },
+            { name: "email", type: "string" },
+            { name: "hire_date", type: "DateTime" },
+            { name: "salary", type: "number" },
+            { name: "job_title", type: "string" },
+            { name: "manager_id", type: "number" },
+            { name: "is_active", type: "boolean" },
+          ],
+          relations: [
+            {
+              name: "department",
+              isList: false,
+              targetTable: "departments",
+              targetSchema: "hr",
+              sourceColumns: ["department_id"],
+              targetColumns: ["id"],
+            },
+          ],
+        },
+        {
+          name: "projects",
+          schema: "hr",
+          columns: [
+            { name: "id", type: "number" },
+            { name: "name", type: "string" },
+            { name: "department_id", type: "number" },
+            { name: "start_date", type: "DateTime" },
+            { name: "end_date", type: "DateTime" },
+            { name: "status", type: "string" },
+            { name: "budget", type: "number" },
+          ],
+          relations: [],
+        },
+        {
+          name: "project_assignments",
+          schema: "hr",
+          columns: [
+            { name: "id", type: "number" },
+            { name: "project_id", type: "number" },
+            { name: "employee_id", type: "number" },
+            { name: "role", type: "string" },
+            { name: "hours_allocated", type: "number" },
+            { name: "assigned_at", type: "DateTime" },
+          ],
+          relations: [],
+        },
+        {
+          name: "time_entries",
+          schema: "hr",
+          columns: [
+            { name: "id", type: "number" },
+            { name: "employee_id", type: "number" },
+            { name: "project_id", type: "number" },
+            { name: "date", type: "DateTime" },
+            { name: "hours", type: "number" },
+            { name: "description", type: "string" },
+          ],
+          relations: [],
+        },
+      ],
+      databaseSchema: "hr",
+    };
+
+    hrCtx = {
+      schema: hrSchema,
+      dialect: "mysql",
+    };
+
+    // Get public schema context using existing test helper
+    publicCtx = await getTestContext();
+  });
+
+  afterAll(async () => {
+    if (db) await db.destroy();
+    await clearSchemaCache?.();
+  });
+
+  describe("findMany with tableSchema (database)", () => {
+    it("queries hr.departments with database qualification", async () => {
+      const iql = {
+        operation: "findMany" as const,
+        table: "departments",
+        tableSchema: "hr",
+        tableConditions: null,
+        whereAndArray: [],
+        operationParameters: {
+          select: {
+            departments: ["id", "name", "budget", "location"],
+          },
+          orderBy: { column: "id", direction: "asc" as const },
+          limit: 10,
+        },
+      };
+
+      const parsed = QuerySchema.parse(iql);
+      const response = await findMany(db, parsed, hrCtx);
+
+      // Verify the SQL includes database qualification
+      expect(containsSchemaTable(response.query.sql, "hr", "departments")).toBe(true);
+      expect(response.data).toBeDefined();
+      expect(Array.isArray(response.data)).toBe(true);
+      expect(response.data.length).toBeGreaterThan(0);
+    });
+
+    it("queries hr.employees with database qualification", async () => {
+      const iql = {
+        operation: "findMany" as const,
+        table: "employees",
+        tableSchema: "hr",
+        tableConditions: null,
+        whereAndArray: [],
+        operationParameters: {
+          select: {
+            employees: ["id", "first_name", "last_name", "salary", "job_title"],
+          },
+          orderBy: { column: "id", direction: "asc" as const },
+          limit: 10,
+        },
+      };
+
+      const parsed = QuerySchema.parse(iql);
+      const response = await findMany(db, parsed, hrCtx);
+
+      expect(containsSchemaTable(response.query.sql, "hr", "employees")).toBe(true);
+      expect(response.data).toBeDefined();
+      expect(response.data.length).toBeGreaterThan(0);
+    });
+
+    it("queries hr.employees with WHERE conditions", async () => {
+      const iql = {
+        operation: "findMany" as const,
+        table: "employees",
+        tableSchema: "hr",
+        tableConditions: null,
+        whereAndArray: [
+          {
+            "employees.salary": { gte: 100000 },
+          },
+        ],
+        operationParameters: {
+          select: {
+            employees: ["id", "first_name", "last_name", "salary"],
+          },
+          orderBy: { column: "salary", direction: "desc" as const },
+          limit: 5,
+        },
+      };
+
+      const parsed = QuerySchema.parse(iql);
+      const response = await findMany(db, parsed, hrCtx);
+
+      expect(containsSchemaTable(response.query.sql, "hr", "employees")).toBe(true);
+      expect(response.data).toBeDefined();
+    });
+  });
+
+  describe("count with tableSchema (database)", () => {
+    it("counts hr.employees", async () => {
+      const iql = {
+        operation: "count" as const,
+        table: "employees",
+        tableSchema: "hr",
+        tableConditions: null,
+        whereAndArray: [],
+        operationParameters: {
+          count: ["employees.id"],
+        },
+      };
+
+      const parsed = QuerySchema.parse(iql);
+      const response = await count(db, parsed, hrCtx);
+
+      expect(containsSchemaTable(response.query.sql, "hr", "employees")).toBe(true);
+      expect(response.data).toBeDefined();
+      expect(response.data._count).toBeDefined();
+    });
+
+    it("counts hr.departments", async () => {
+      const iql = {
+        operation: "count" as const,
+        table: "departments",
+        tableSchema: "hr",
+        tableConditions: null,
+        whereAndArray: [],
+        operationParameters: {
+          count: ["departments.id"],
+        },
+      };
+
+      const parsed = QuerySchema.parse(iql);
+      const response = await count(db, parsed, hrCtx);
+
+      expect(containsSchemaTable(response.query.sql, "hr", "departments")).toBe(true);
+      expect(response.data._count["departments.id"]).toBe(5);
+    });
+  });
+
+  describe("groupBy with tableSchema (database)", () => {
+    it("groups hr.employees by department", async () => {
+      const iql = {
+        operation: "groupBy" as const,
+        table: "employees",
+        tableSchema: "hr",
+        tableConditions: null,
+        whereAndArray: [],
+        operationParameters: {
+          groupBy: [{ type: "column" as const, column: "employees.department_id" }],
+          count: ["employees.id"],
+          countDistinct: null,
+          sum: null,
+          min: null,
+          max: null,
+          avg: null,
+          orderBy: { type: "aggregate" as const, function: "count" as const, column: "employees.id", direction: "desc" as const },
+          limit: 10,
+        },
+      };
+
+      const parsed = QuerySchema.parse(iql);
+      const response = await groupBy(db, parsed, hrCtx);
+
+      expect(containsSchemaTable(response.query.sql, "hr", "employees")).toBe(true);
+      expect(response.data).toBeDefined();
+      expect(Array.isArray(response.data)).toBe(true);
+    });
+  });
+
+  describe("aggregate with tableSchema (database)", () => {
+    it("aggregates hr.employees salaries", async () => {
+      const iql = {
+        operation: "aggregate" as const,
+        table: "employees",
+        tableSchema: "hr",
+        tableConditions: null,
+        whereAndArray: [],
+        operationParameters: {
+          sum: ["employees.salary"],
+          avg: ["employees.salary"],
+          min: ["employees.salary"],
+          max: ["employees.salary"],
+          count: ["employees.id"],
+          countDistinct: null,
+          median: null,
+        },
+      };
+
+      const parsed = QuerySchema.parse(iql);
+      const response = await aggregate(db, parsed, hrCtx);
+
+      expect(containsSchemaTable(response.query.sql, "hr", "employees")).toBe(true);
+      expect(response.data).toBeDefined();
+      expect(response.data._sum).toBeDefined();
+      expect(response.data._avg).toBeDefined();
+    });
+  });
+
+  describe("verify database isolation", () => {
+    it("hosted.users and hr.employees are separate tables", async () => {
+      // Query hosted database users
+      const hostedQuery = {
+        operation: "count" as const,
+        table: "users",
+        tableConditions: null,
+        whereAndArray: [],
+        operationParameters: {
+          count: ["users.id"],
+        },
+      };
+
+      // Query hr database employees
+      const hrQuery = {
+        operation: "count" as const,
+        table: "employees",
+        tableSchema: "hr",
+        tableConditions: null,
+        whereAndArray: [],
+        operationParameters: {
+          count: ["employees.id"],
+        },
+      };
+
+      const hostedParsed = QuerySchema.parse(hostedQuery);
+      const hrParsed = QuerySchema.parse(hrQuery);
+
+      const hostedResponse = await count(db, hostedParsed, publicCtx);
+      const hrResponse = await count(db, hrParsed, hrCtx);
+
+      // Hosted should NOT contain hr database qualification
+      expect(containsSchemaTable(hostedResponse.query.sql, "hr", "users")).toBe(false);
+      // HR should contain hr database qualification
+      expect(containsSchemaTable(hrResponse.query.sql, "hr", "employees")).toBe(true);
+
+      // Both should have data
+      expect(hostedResponse.data._count["users.id"]).toBeGreaterThan(0);
+      expect(hrResponse.data._count["employees.id"]).toBe(12);
+    });
+  });
+});

--- a/packages/connect/test/pg/multiSchema.test.ts
+++ b/packages/connect/test/pg/multiSchema.test.ts
@@ -1,0 +1,686 @@
+// @ts-nocheck
+/**
+ * Multi-Schema Tests for PostgreSQL
+ *
+ * Tests schema-qualified table names when querying tables in different schemas.
+ * Requires the demo database with both `public` and `hr` schemas.
+ */
+import { sql } from "kysely";
+import type { Kysely } from "kysely";
+import { loadTestEnv, getTestContext } from "../loadTestEnv";
+import type { SchemaResponse } from "../../src/types/types";
+import type { OperationContext } from "../../src/operations/types";
+
+describe("PostgreSQL Multi-Schema Operations", () => {
+  let db: Kysely<any>;
+  let QuerySchema: (typeof import("~/types/querySchema"))["QuerySchema"];
+  let findMany: (typeof import("~/operations/findMany"))["findMany"];
+  let count: (typeof import("~/operations/count"))["count"];
+  let groupBy: (typeof import("~/operations/groupBy"))["groupBy"];
+  let aggregate: (typeof import("~/operations/aggregate"))["aggregate"];
+  let clearSchemaCache: (typeof import("~/util/schemaCache"))["clearSchemaCache"];
+
+  // Custom context with HR schema tables
+  let hrCtx: OperationContext;
+  let publicCtx: OperationContext;
+
+  // Helper to check if SQL contains schema-qualified table reference
+  // PostgreSQL quotes identifiers, so "hr"."employees" is valid
+  const containsSchemaTable = (sqlStr: string, schema: string, table: string) => {
+    return (
+      sqlStr.includes(`${schema}.${table}`) ||
+      sqlStr.includes(`"${schema}"."${table}"`) ||
+      sqlStr.includes(`"${schema}".${table}`) ||
+      sqlStr.includes(`${schema}."${table}"`)
+    );
+  };
+
+  beforeAll(async () => {
+    loadTestEnv("postgresql");
+
+    jest.resetModules();
+    delete (globalThis as any).__INCONVO_KYSELY_DB__;
+
+    ({ clearSchemaCache } = await import("~/util/schemaCache"));
+    await clearSchemaCache();
+
+    QuerySchema = (await import("~/types/querySchema")).QuerySchema;
+    findMany = (await import("~/operations/findMany")).findMany;
+    count = (await import("~/operations/count")).count;
+    groupBy = (await import("~/operations/groupBy")).groupBy;
+    aggregate = (await import("~/operations/aggregate")).aggregate;
+    const { getDb } = await import("~/dbConnection");
+    db = await getDb();
+
+    // Build HR schema context manually
+    const hrSchema: SchemaResponse = {
+      tables: [
+        {
+          name: "departments",
+          schema: "hr",
+          columns: [
+            { name: "id", type: "number" },
+            { name: "name", type: "string" },
+            { name: "budget", type: "number" },
+            { name: "location", type: "string" },
+            { name: "created_at", type: "DateTime" },
+          ],
+          relations: [
+            {
+              name: "employees",
+              isList: true,
+              targetTable: "employees",
+              targetSchema: "hr",
+              sourceColumns: ["id"],
+              targetColumns: ["department_id"],
+            },
+            {
+              name: "projects",
+              isList: true,
+              targetTable: "projects",
+              targetSchema: "hr",
+              sourceColumns: ["id"],
+              targetColumns: ["department_id"],
+            },
+          ],
+        },
+        {
+          name: "employees",
+          schema: "hr",
+          columns: [
+            { name: "id", type: "number" },
+            { name: "department_id", type: "number" },
+            { name: "first_name", type: "string" },
+            { name: "last_name", type: "string" },
+            { name: "email", type: "string" },
+            { name: "hire_date", type: "DateTime" },
+            { name: "salary", type: "number" },
+            { name: "job_title", type: "string" },
+            { name: "manager_id", type: "number" },
+            { name: "is_active", type: "boolean" },
+          ],
+          relations: [
+            {
+              name: "department",
+              isList: false,
+              targetTable: "departments",
+              targetSchema: "hr",
+              sourceColumns: ["department_id"],
+              targetColumns: ["id"],
+            },
+            {
+              name: "manager",
+              isList: false,
+              targetTable: "employees",
+              targetSchema: "hr",
+              sourceColumns: ["manager_id"],
+              targetColumns: ["id"],
+            },
+          ],
+        },
+        {
+          name: "projects",
+          schema: "hr",
+          columns: [
+            { name: "id", type: "number" },
+            { name: "name", type: "string" },
+            { name: "department_id", type: "number" },
+            { name: "start_date", type: "DateTime" },
+            { name: "end_date", type: "DateTime" },
+            { name: "status", type: "string" },
+            { name: "budget", type: "number" },
+          ],
+          relations: [
+            {
+              name: "department",
+              isList: false,
+              targetTable: "departments",
+              targetSchema: "hr",
+              sourceColumns: ["department_id"],
+              targetColumns: ["id"],
+            },
+          ],
+        },
+        {
+          name: "project_assignments",
+          schema: "hr",
+          columns: [
+            { name: "id", type: "number" },
+            { name: "project_id", type: "number" },
+            { name: "employee_id", type: "number" },
+            { name: "role", type: "string" },
+            { name: "hours_allocated", type: "number" },
+            { name: "assigned_at", type: "DateTime" },
+          ],
+          relations: [],
+        },
+        {
+          name: "time_entries",
+          schema: "hr",
+          columns: [
+            { name: "id", type: "number" },
+            { name: "employee_id", type: "number" },
+            { name: "project_id", type: "number" },
+            { name: "date", type: "DateTime" },
+            { name: "hours", type: "number" },
+            { name: "description", type: "string" },
+          ],
+          relations: [],
+        },
+      ],
+      databaseSchema: "hr",
+    };
+
+    hrCtx = {
+      schema: hrSchema,
+      dialect: "postgresql",
+    };
+
+    // Get public schema context using existing test helper
+    publicCtx = await getTestContext();
+  });
+
+  afterAll(async () => {
+    if (db) await db.destroy();
+    await clearSchemaCache?.();
+  });
+
+  describe("findMany with tableSchema", () => {
+    it("queries hr.departments with schema qualification", async () => {
+      const iql = {
+        operation: "findMany" as const,
+        table: "departments",
+        tableSchema: "hr",
+        tableConditions: null,
+        whereAndArray: [],
+        operationParameters: {
+          select: {
+            departments: ["id", "name", "budget", "location"],
+          },
+          orderBy: { column: "id", direction: "asc" as const },
+          limit: 10,
+        },
+      };
+
+      const parsed = QuerySchema.parse(iql);
+      const response = await findMany(db, parsed, hrCtx);
+
+      // Verify the SQL includes schema qualification (with or without quotes)
+      expect(containsSchemaTable(response.query.sql, "hr", "departments")).toBe(true);
+      expect(response.data).toBeDefined();
+      expect(Array.isArray(response.data)).toBe(true);
+      expect(response.data.length).toBeGreaterThan(0);
+    });
+
+    it("queries hr.employees with schema qualification", async () => {
+      const iql = {
+        operation: "findMany" as const,
+        table: "employees",
+        tableSchema: "hr",
+        tableConditions: null,
+        whereAndArray: [],
+        operationParameters: {
+          select: {
+            employees: ["id", "first_name", "last_name", "salary", "job_title"],
+          },
+          orderBy: { column: "id", direction: "asc" as const },
+          limit: 10,
+        },
+      };
+
+      const parsed = QuerySchema.parse(iql);
+      const response = await findMany(db, parsed, hrCtx);
+
+      expect(containsSchemaTable(response.query.sql, "hr", "employees")).toBe(true);
+      expect(response.data).toBeDefined();
+      expect(response.data.length).toBeGreaterThan(0);
+    });
+
+    it("queries hr.employees with WHERE conditions", async () => {
+      const iql = {
+        operation: "findMany" as const,
+        table: "employees",
+        tableSchema: "hr",
+        tableConditions: null,
+        whereAndArray: [
+          {
+            "employees.salary": { gte: 100000 },
+          },
+        ],
+        operationParameters: {
+          select: {
+            employees: ["id", "first_name", "last_name", "salary"],
+          },
+          orderBy: { column: "salary", direction: "desc" as const },
+          limit: 5,
+        },
+      };
+
+      const parsed = QuerySchema.parse(iql);
+      const response = await findMany(db, parsed, hrCtx);
+
+      expect(containsSchemaTable(response.query.sql, "hr", "employees")).toBe(true);
+      expect(response.data).toBeDefined();
+      // All returned employees should have salary >= 100000
+      response.data.forEach((row: any) => {
+        expect(Number(row.employees_salary)).toBeGreaterThanOrEqual(100000);
+      });
+    });
+
+    it("queries hr.projects with status filter", async () => {
+      const iql = {
+        operation: "findMany" as const,
+        table: "projects",
+        tableSchema: "hr",
+        tableConditions: null,
+        whereAndArray: [
+          {
+            "projects.status": { equals: "active" },
+          },
+        ],
+        operationParameters: {
+          select: {
+            projects: ["id", "name", "status", "budget"],
+          },
+          orderBy: { column: "id", direction: "asc" as const },
+          limit: 10,
+        },
+      };
+
+      const parsed = QuerySchema.parse(iql);
+      const response = await findMany(db, parsed, hrCtx);
+
+      expect(containsSchemaTable(response.query.sql, "hr", "projects")).toBe(true);
+      expect(response.data).toBeDefined();
+      response.data.forEach((row: any) => {
+        expect(row.projects_status).toBe("active");
+      });
+    });
+  });
+
+  describe("count with tableSchema", () => {
+    it("counts hr.employees", async () => {
+      const iql = {
+        operation: "count" as const,
+        table: "employees",
+        tableSchema: "hr",
+        tableConditions: null,
+        whereAndArray: [],
+        operationParameters: {
+          count: ["employees.id"],
+        },
+      };
+
+      const parsed = QuerySchema.parse(iql);
+      const response = await count(db, parsed, hrCtx);
+
+      expect(containsSchemaTable(response.query.sql, "hr", "employees")).toBe(true);
+      expect(response.data).toBeDefined();
+      expect(response.data._count).toBeDefined();
+    });
+
+    it("counts hr.departments", async () => {
+      const iql = {
+        operation: "count" as const,
+        table: "departments",
+        tableSchema: "hr",
+        tableConditions: null,
+        whereAndArray: [],
+        operationParameters: {
+          count: ["departments.id"],
+        },
+      };
+
+      const parsed = QuerySchema.parse(iql);
+      const response = await count(db, parsed, hrCtx);
+
+      expect(containsSchemaTable(response.query.sql, "hr", "departments")).toBe(true);
+      expect(response.data._count["departments.id"]).toBe(5); // 5 departments in HR schema
+    });
+
+    it("counts hr.projects by status", async () => {
+      const iql = {
+        operation: "count" as const,
+        table: "projects",
+        tableSchema: "hr",
+        tableConditions: null,
+        whereAndArray: [
+          {
+            "projects.status": { equals: "active" },
+          },
+        ],
+        operationParameters: {
+          count: ["projects.id"],
+        },
+      };
+
+      const parsed = QuerySchema.parse(iql);
+      const response = await count(db, parsed, hrCtx);
+
+      expect(containsSchemaTable(response.query.sql, "hr", "projects")).toBe(true);
+      expect(response.data._count["projects.id"]).toBeGreaterThan(0);
+    });
+  });
+
+  describe("groupBy with tableSchema", () => {
+    it("groups hr.employees by department", async () => {
+      const iql = {
+        operation: "groupBy" as const,
+        table: "employees",
+        tableSchema: "hr",
+        tableConditions: null,
+        whereAndArray: [],
+        operationParameters: {
+          groupBy: [{ type: "column" as const, column: "employees.department_id" }],
+          count: ["employees.id"],
+          countDistinct: null,
+          sum: null,
+          min: null,
+          max: null,
+          avg: null,
+          orderBy: { type: "aggregate" as const, function: "count" as const, column: "employees.id", direction: "desc" as const },
+          limit: 10,
+        },
+      };
+
+      const parsed = QuerySchema.parse(iql);
+      const response = await groupBy(db, parsed, hrCtx);
+
+      expect(containsSchemaTable(response.query.sql, "hr", "employees")).toBe(true);
+      expect(response.data).toBeDefined();
+      expect(Array.isArray(response.data)).toBe(true);
+    });
+
+    it("groups hr.projects by status with aggregates", async () => {
+      const iql = {
+        operation: "groupBy" as const,
+        table: "projects",
+        tableSchema: "hr",
+        tableConditions: null,
+        whereAndArray: [],
+        operationParameters: {
+          groupBy: [{ type: "column" as const, column: "projects.status" }],
+          count: ["projects.id"],
+          countDistinct: null,
+          sum: ["projects.budget"],
+          min: null,
+          max: null,
+          avg: null,
+          orderBy: { type: "aggregate" as const, function: "count" as const, column: "projects.id", direction: "desc" as const },
+          limit: 10,
+        },
+      };
+
+      const parsed = QuerySchema.parse(iql);
+      const response = await groupBy(db, parsed, hrCtx);
+
+      expect(containsSchemaTable(response.query.sql, "hr", "projects")).toBe(true);
+      expect(response.data).toBeDefined();
+      expect(Array.isArray(response.data)).toBe(true);
+    });
+  });
+
+  describe("aggregate with tableSchema", () => {
+    it("aggregates hr.employees salaries", async () => {
+      const iql = {
+        operation: "aggregate" as const,
+        table: "employees",
+        tableSchema: "hr",
+        tableConditions: null,
+        whereAndArray: [],
+        operationParameters: {
+          sum: ["employees.salary"],
+          avg: ["employees.salary"],
+          min: ["employees.salary"],
+          max: ["employees.salary"],
+          count: ["employees.id"],
+          countDistinct: null,
+          median: null,
+        },
+      };
+
+      const parsed = QuerySchema.parse(iql);
+      const response = await aggregate(db, parsed, hrCtx);
+
+      expect(containsSchemaTable(response.query.sql, "hr", "employees")).toBe(true);
+      expect(response.data).toBeDefined();
+      expect(response.data._sum).toBeDefined();
+      expect(response.data._avg).toBeDefined();
+      expect(response.data._min).toBeDefined();
+      expect(response.data._max).toBeDefined();
+      expect(response.data._count).toBeDefined();
+    });
+
+    it("aggregates hr.projects budgets", async () => {
+      const iql = {
+        operation: "aggregate" as const,
+        table: "projects",
+        tableSchema: "hr",
+        tableConditions: null,
+        whereAndArray: [],
+        operationParameters: {
+          sum: ["projects.budget"],
+          avg: null,
+          min: null,
+          max: null,
+          count: ["projects.id"],
+          countDistinct: null,
+          median: null,
+        },
+      };
+
+      const parsed = QuerySchema.parse(iql);
+      const response = await aggregate(db, parsed, hrCtx);
+
+      expect(containsSchemaTable(response.query.sql, "hr", "projects")).toBe(true);
+      expect(response.data._sum["projects.budget"]).toBeGreaterThan(0);
+    });
+  });
+
+  describe("relation filters with tableSchema", () => {
+    it("filters hr.employees with department relation filter", async () => {
+      const iql = {
+        operation: "findMany" as const,
+        table: "employees",
+        tableSchema: "hr",
+        tableConditions: null,
+        whereAndArray: [
+          {
+            AND: [
+              {
+                department: {
+                  is: {
+                    name: { equals: "Engineering" },
+                  },
+                },
+              },
+            ],
+          },
+        ],
+        operationParameters: {
+          select: {
+            employees: ["id", "first_name", "last_name", "job_title"],
+          },
+          orderBy: { column: "id", direction: "asc" as const },
+          limit: 10,
+        },
+      };
+
+      const parsed = QuerySchema.parse(iql);
+      const response = await findMany(db, parsed, hrCtx);
+
+      // Should use schema-qualified names for both tables in the relation filter
+      expect(containsSchemaTable(response.query.sql, "hr", "employees")).toBe(true);
+      expect(containsSchemaTable(response.query.sql, "hr", "departments")).toBe(true);
+      expect(response.data).toBeDefined();
+    });
+
+    it("filters hr.departments with employees some filter", async () => {
+      const iql = {
+        operation: "findMany" as const,
+        table: "departments",
+        tableSchema: "hr",
+        tableConditions: null,
+        whereAndArray: [
+          {
+            AND: [
+              {
+                employees: {
+                  some: {
+                    salary: { gte: 150000 },
+                  },
+                },
+              },
+            ],
+          },
+        ],
+        operationParameters: {
+          select: {
+            departments: ["id", "name"],
+          },
+          orderBy: { column: "id", direction: "asc" as const },
+          limit: 10,
+        },
+      };
+
+      const parsed = QuerySchema.parse(iql);
+      const response = await findMany(db, parsed, hrCtx);
+
+      expect(containsSchemaTable(response.query.sql, "hr", "departments")).toBe(true);
+      expect(containsSchemaTable(response.query.sql, "hr", "employees")).toBe(true);
+      expect(response.data).toBeDefined();
+    });
+  });
+
+  describe("JOINs with tableSchema", () => {
+    it("joins hr.employees with hr.departments", async () => {
+      const iql = {
+        operation: "findMany" as const,
+        table: "employees",
+        tableSchema: "hr",
+        tableConditions: null,
+        whereAndArray: [],
+        operationParameters: {
+          select: {
+            employees: ["id", "first_name", "last_name"],
+            "employees.department": ["name"],
+          },
+          joins: [
+            {
+              table: "departments",
+              name: "employees.department",
+              path: [
+                {
+                  source: ["employees.department_id"],
+                  target: ["departments.id"],
+                },
+              ],
+            },
+          ],
+          orderBy: { column: "id", direction: "asc" as const },
+          limit: 10,
+        },
+      };
+
+      const parsed = QuerySchema.parse(iql);
+      const response = await findMany(db, parsed, hrCtx);
+
+      // Should use schema-qualified names for both tables in the JOIN
+      expect(containsSchemaTable(response.query.sql, "hr", "employees")).toBe(true);
+      expect(containsSchemaTable(response.query.sql, "hr", "departments")).toBe(true);
+      expect(response.data).toBeDefined();
+      expect(response.data.length).toBeGreaterThan(0);
+    });
+
+    it("joins hr.project_assignments with hr.employees and hr.projects", async () => {
+      const iql = {
+        operation: "findMany" as const,
+        table: "project_assignments",
+        tableSchema: "hr",
+        tableConditions: null,
+        whereAndArray: [],
+        operationParameters: {
+          select: {
+            project_assignments: ["id", "role", "hours_allocated"],
+            "project_assignments.employee": ["first_name", "last_name"],
+            "project_assignments.project": ["name"],
+          },
+          joins: [
+            {
+              table: "employees",
+              name: "project_assignments.employee",
+              path: [
+                {
+                  source: ["project_assignments.employee_id"],
+                  target: ["employees.id"],
+                },
+              ],
+            },
+            {
+              table: "projects",
+              name: "project_assignments.project",
+              path: [
+                {
+                  source: ["project_assignments.project_id"],
+                  target: ["projects.id"],
+                },
+              ],
+            },
+          ],
+          orderBy: { column: "id", direction: "asc" as const },
+          limit: 10,
+        },
+      };
+
+      const parsed = QuerySchema.parse(iql);
+      const response = await findMany(db, parsed, hrCtx);
+
+      expect(containsSchemaTable(response.query.sql, "hr", "project_assignments")).toBe(true);
+      expect(containsSchemaTable(response.query.sql, "hr", "employees")).toBe(true);
+      expect(containsSchemaTable(response.query.sql, "hr", "projects")).toBe(true);
+      expect(response.data).toBeDefined();
+    });
+  });
+
+  describe("verify schema isolation", () => {
+    it("public.users and hr.employees are separate tables", async () => {
+      // Query public schema users
+      const publicQuery = {
+        operation: "count" as const,
+        table: "users",
+        tableConditions: null,
+        whereAndArray: [],
+        operationParameters: {
+          count: ["users.id"],
+        },
+      };
+
+      // Query hr schema employees
+      const hrQuery = {
+        operation: "count" as const,
+        table: "employees",
+        tableSchema: "hr",
+        tableConditions: null,
+        whereAndArray: [],
+        operationParameters: {
+          count: ["employees.id"],
+        },
+      };
+
+      const publicParsed = QuerySchema.parse(publicQuery);
+      const hrParsed = QuerySchema.parse(hrQuery);
+
+      const publicResponse = await count(db, publicParsed, publicCtx);
+      const hrResponse = await count(db, hrParsed, hrCtx);
+
+      // Public should NOT contain hr schema qualification
+      expect(containsSchemaTable(publicResponse.query.sql, "hr", "users")).toBe(false);
+      // HR should contain hr schema qualification
+      expect(containsSchemaTable(hrResponse.query.sql, "hr", "employees")).toBe(true);
+
+      // Both should have data
+      expect(publicResponse.data._count["users.id"]).toBeGreaterThan(0);
+      expect(hrResponse.data._count["employees.id"]).toBe(12); // 12 employees in HR
+    });
+  });
+});

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -18,7 +18,7 @@
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-turbo": "^2.6.0",
-    "globals": "^16.5.0",
+    "globals": "^17.1.0",
     "typescript": "catalog:",
     "typescript-eslint": "^8.49.0"
   }

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -35,6 +35,7 @@ const relationSchema = z
 const tableSchema = z
   .object({
     name: z.string(),
+    schema: z.string().optional(),  // Database schema name (e.g., 'public', 'sales')
     columns: z.array(columnSchema),
     relations: z.array(relationSchema).optional(),
   })
@@ -43,6 +44,7 @@ const tableSchema = z
 export const SchemaResponseSchema = z
   .object({
     tables: z.array(tableSchema),
+    databaseSchema: z.string().nullable().optional(),  // Default schema for the connection
   })
   .strict();
 
@@ -444,6 +446,7 @@ export type TableConditionsMap = z.infer<typeof tableConditionsMapSchema>;
 
 const baseSchema = {
   table: z.string(),
+  tableSchema: z.string().nullable().optional(),  // Database schema name (e.g., 'public', 'sales')
   whereAndArray: whereAndArraySchema,
   tableConditions: tableConditionsMapSchema,
 };
@@ -1074,6 +1077,7 @@ export type SchemaRelation = {
   name: string;
   relationId: string | null;
   targetTable: { name: string };
+  targetSchema: string | null;  // For cross-schema relations
   isList: boolean;
   selected: boolean;
   source: RelationSource;
@@ -1085,6 +1089,7 @@ export type SchemaRelation = {
 
 export type SchemaTable = {
   name: string;
+  schema: string | null;  // Database schema name (e.g., 'public', 'sales')
   access: TableAccess;
   context: string | null;
   columns: SchemaColumn[];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,6 +120,9 @@ catalogs:
     vitest:
       specifier: 4.0.18
       version: 4.0.18
+    wrangler:
+      specifier: 4.60.0
+      version: 4.60.0
     yaml:
       specifier: 2.8.2
       version: 2.8.2
@@ -311,8 +314,8 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
       wrangler:
-        specifier: ^4.59.3
-        version: 4.61.0
+        specifier: 'catalog:'
+        version: 4.60.0
 
   packages/agents:
     dependencies:
@@ -393,7 +396,7 @@ importers:
         specifier: 'catalog:'
         version: 8.17.2
       yaml:
-        specifier: ^2.7.0
+        specifier: 'catalog:'
         version: 2.8.2
     devDependencies:
       '@repo/eslint-config':
@@ -457,8 +460,8 @@ importers:
         specifier: 'catalog:'
         version: 8.17.2
       pino:
-        specifier: ^9.9.0
-        version: 9.14.0
+        specifier: ^10.3.0
+        version: 10.3.0
       pino-pretty:
         specifier: ^13.1.1
         version: 13.1.3
@@ -466,8 +469,8 @@ importers:
         specifier: ^3.0.2
         version: 3.0.2
       tedious:
-        specifier: ^18.0.0
-        version: 18.6.2
+        specifier: ^19.2.0
+        version: 19.2.0
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -536,8 +539,8 @@ importers:
         specifier: ^2.6.0
         version: 2.7.6(eslint@9.39.2(jiti@2.6.1))(turbo@2.7.6)
       globals:
-        specifier: ^16.5.0
-        version: 16.5.0
+        specifier: ^17.1.0
+        version: 17.2.0
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -926,32 +929,32 @@ packages:
       workerd:
         optional: true
 
-  '@cloudflare/workerd-darwin-64@1.20260124.0':
-    resolution: {integrity: sha512-VuqscLhiiVIf7t/dcfkjtT0LKJH+a06KUFwFTHgdTcqyLbFZ44u1SLpOONu5fyva4A9MdaKh9a+Z/tBC1d76nw==}
+  '@cloudflare/workerd-darwin-64@1.20260120.0':
+    resolution: {integrity: sha512-JLHx3p5dpwz4wjVSis45YNReftttnI3ndhdMh5BUbbpdreN/g0jgxNt5Qp9tDFqEKl++N63qv+hxJiIIvSLR+Q==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [darwin]
 
-  '@cloudflare/workerd-darwin-arm64@1.20260124.0':
-    resolution: {integrity: sha512-PfnjoFooPgRKFUIZcEP9irnn5Y7OgXinjM+IMlKTdEyLWjMblLsbsqAgydf75+ii0715xAeUlWQjZrWdyOZjMw==}
+  '@cloudflare/workerd-darwin-arm64@1.20260120.0':
+    resolution: {integrity: sha512-1Md2tCRhZjwajsZNOiBeOVGiS3zbpLPzUDjHr4+XGTXWOA6FzzwScJwQZLa0Doc28Cp4Nr1n7xGL0Dwiz1XuOA==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [darwin]
 
-  '@cloudflare/workerd-linux-64@1.20260124.0':
-    resolution: {integrity: sha512-KSkZl4kwcWeFXI7qsaLlMnKwjgdZwI0OEARjyZpiHCxJCqAqla9XxQKNDscL2Z3qUflIo30i+uteGbFrhzuVGQ==}
+  '@cloudflare/workerd-linux-64@1.20260120.0':
+    resolution: {integrity: sha512-O0mIfJfvU7F8N5siCoRDaVDuI12wkz2xlG4zK6/Ct7U9c9FiE0ViXNFWXFQm5PPj+qbkNRyhjUwhP+GCKTk5EQ==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [linux]
 
-  '@cloudflare/workerd-linux-arm64@1.20260124.0':
-    resolution: {integrity: sha512-61xjSUNk745EVV4vXZP0KGyLCatcmamfBB+dcdQ8kDr6PrNU4IJ1kuQFSJdjybyDhJRm4TpGVywq+9hREuF7xA==}
+  '@cloudflare/workerd-linux-arm64@1.20260120.0':
+    resolution: {integrity: sha512-aRHO/7bjxVpjZEmVVcpmhbzpN6ITbFCxuLLZSW0H9O0C0w40cDCClWSi19T87Ax/PQcYjFNT22pTewKsupkckA==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [linux]
 
-  '@cloudflare/workerd-windows-64@1.20260124.0':
-    resolution: {integrity: sha512-j9O11pwQQV6Vi3peNrJoyIas3SrZHlPj0Ah+z1hDW9o1v35euVBQJw/PuzjPOXxTFUlGQoMJdfzPsO9xP86g7A==}
+  '@cloudflare/workerd-windows-64@1.20260120.0':
+    resolution: {integrity: sha512-ASZIz1E8sqZQqQCgcfY1PJbBpUDrxPt8NZ+lqNil0qxnO4qX38hbCsdDF2/TDAuq0Txh7nu8ztgTelfNDlb4EA==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
@@ -3538,8 +3541,8 @@ packages:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
     engines: {node: '>=18'}
 
-  globals@16.5.0:
-    resolution: {integrity: sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ==}
+  globals@17.2.0:
+    resolution: {integrity: sha512-tovnCz/fEq+Ripoq+p/gN1u7l6A7wwkoBT9pRCzTHzsD/LvADIzXZdjmRymh5Ztf0DYC3Rwg5cZRYjxzBmzbWg==}
     engines: {node: '>=18'}
 
   globalthis@1.0.4:
@@ -4242,8 +4245,8 @@ packages:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
     engines: {node: '>=10'}
 
-  miniflare@4.20260124.0:
-    resolution: {integrity: sha512-Co8onUh+POwOuLty4myQg+Nzg9/xZ5eAJc1oqYBzRovHd/XIpb5WAnRVaubcfAQJ85awWtF3yXUHCDx6cIaN3w==}
+  miniflare@4.20260120.0:
+    resolution: {integrity: sha512-XXZyE2pDKMtP5OLuv0LPHEAzIYhov4jrYjcqrhhqtxGGtXneWOHvXIPo+eV8sqwqWd3R7j4DlEKcyb+87BR49Q==}
     engines: {node: '>=18.0.0'}
     hasBin: true
 
@@ -4583,9 +4586,6 @@ packages:
     resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
     engines: {node: '>=0.10.0'}
 
-  pino-abstract-transport@2.0.0:
-    resolution: {integrity: sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==}
-
   pino-abstract-transport@3.0.0:
     resolution: {integrity: sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==}
 
@@ -4598,10 +4598,6 @@ packages:
 
   pino@10.3.0:
     resolution: {integrity: sha512-0GNPNzHXBKw6U/InGe79A3Crzyk9bcSyObF9/Gfo9DLEf5qj5RF50RSjsu0W1rZ6ZqRGdzDFCRBQvi9/rSGPtA==}
-    hasBin: true
-
-  pino@9.14.0:
-    resolution: {integrity: sha512-8OEwKp5juEvb/MjpIc4hjqfgCNysrS94RIOMXYvpYCdm/jglrKEiAYmiumbmGhCvs+IcInsphYDFwqrjr7398w==}
     hasBin: true
 
   pirates@4.0.7:
@@ -5262,10 +5258,6 @@ packages:
     resolution: {integrity: sha512-51LAVKUSZSVfI05vjPESNc5vwqqZpbXCsU+/+wxlOrUjk2SnFTt97v9ZgQrD4YmxYW1Px6w2KjaDitCfkvgxMQ==}
     engines: {node: '>=8.0.0'}
 
-  tedious@18.6.2:
-    resolution: {integrity: sha512-g7jC56o3MzLkE3lHkaFe2ZdOVFBahq5bsB60/M4NYUbocw/MCrS89IOEQUFr+ba6pb8ZHczZ/VqCyYeYq0xBAg==}
-    engines: {node: '>=18'}
-
   tedious@19.2.0:
     resolution: {integrity: sha512-2dDjX0KP54riDvJPiiIozv0WRS/giJb3/JG2lWpa2dgM0Gha7mLAxbTR3ltPkGzfoS6M3oDnhYnWuzeaZibHuQ==}
     engines: {node: '>=18.17'}
@@ -5277,9 +5269,6 @@ packages:
   test-exclude@6.0.0:
     resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
     engines: {node: '>=8'}
-
-  thread-stream@3.1.0:
-    resolution: {integrity: sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==}
 
   thread-stream@4.0.0:
     resolution: {integrity: sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA==}
@@ -5801,17 +5790,17 @@ packages:
   wordwrap@1.0.0:
     resolution: {integrity: sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==}
 
-  workerd@1.20260124.0:
-    resolution: {integrity: sha512-JN6voV/fUQK342a39Rl+20YVmtIXZVbpxc7V/m809lUnlTGPy4aa5MI7PMoc+9qExgAEOw9cojvN5zOfqmMWLg==}
+  workerd@1.20260120.0:
+    resolution: {integrity: sha512-R6X/VQOkwLTBGLp4VRUwLQZZVxZ9T9J8pGiJ6GQUMaRkY7TVWrCSkVfoNMM1/YyFsY5UYhhPoQe5IehnhZ3Pdw==}
     engines: {node: '>=16'}
     hasBin: true
 
-  wrangler@4.61.0:
-    resolution: {integrity: sha512-Kb8NMe1B/HM7/ds3hU+fcV1U7T996vRKJ0UU/qqgNUMwdemTRA+sSaH3mQvQslIBbprHHU81s0huA6fDIcwiaQ==}
+  wrangler@4.60.0:
+    resolution: {integrity: sha512-n4kibm/xY0Qd5G2K/CbAQeVeOIlwPNVglmFjlDRCCYk3hZh8IggO/rg8AXt/vByK2Sxsugl5Z7yvgWxrUbmS6g==}
     engines: {node: '>=20.0.0'}
     hasBin: true
     peerDependencies:
-      '@cloudflare/workers-types': ^4.20260124.0
+      '@cloudflare/workers-types': ^4.20260120.0
     peerDependenciesMeta:
       '@cloudflare/workers-types':
         optional: true
@@ -5895,6 +5884,9 @@ packages:
 
   zeptomatch@2.1.0:
     resolution: {integrity: sha512-KiGErG2J0G82LSpniV0CtIzjlJ10E04j02VOudJsPyPwNZgGnRKQy7I1R7GMyg/QswnE4l7ohSGrQbQbjXPPDA==}
+
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
@@ -6273,25 +6265,25 @@ snapshots:
     dependencies:
       '@cloudflare/containers': 0.0.30
 
-  '@cloudflare/unenv-preset@2.11.0(unenv@2.0.0-rc.24)(workerd@1.20260124.0)':
+  '@cloudflare/unenv-preset@2.11.0(unenv@2.0.0-rc.24)(workerd@1.20260120.0)':
     dependencies:
       unenv: 2.0.0-rc.24
     optionalDependencies:
-      workerd: 1.20260124.0
+      workerd: 1.20260120.0
 
-  '@cloudflare/workerd-darwin-64@1.20260124.0':
+  '@cloudflare/workerd-darwin-64@1.20260120.0':
     optional: true
 
-  '@cloudflare/workerd-darwin-arm64@1.20260124.0':
+  '@cloudflare/workerd-darwin-arm64@1.20260120.0':
     optional: true
 
-  '@cloudflare/workerd-linux-64@1.20260124.0':
+  '@cloudflare/workerd-linux-64@1.20260120.0':
     optional: true
 
-  '@cloudflare/workerd-linux-arm64@1.20260124.0':
+  '@cloudflare/workerd-linux-arm64@1.20260120.0':
     optional: true
 
-  '@cloudflare/workerd-windows-64@1.20260124.0':
+  '@cloudflare/workerd-windows-64@1.20260120.0':
     optional: true
 
   '@cspotcode/source-map-support@0.8.1':
@@ -8973,7 +8965,7 @@ snapshots:
 
   globals@14.0.0: {}
 
-  globals@16.5.0: {}
+  globals@17.2.0: {}
 
   globalthis@1.0.4:
     dependencies:
@@ -9824,14 +9816,15 @@ snapshots:
 
   mimic-response@3.1.0: {}
 
-  miniflare@4.20260124.0:
+  miniflare@4.20260120.0:
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       sharp: 0.34.5
       undici: 7.18.2
-      workerd: 1.20260124.0
+      workerd: 1.20260120.0
       ws: 8.18.0
       youch: 4.1.0-beta.10
+      zod: 3.25.76
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -10157,10 +10150,6 @@ snapshots:
 
   pify@2.3.0: {}
 
-  pino-abstract-transport@2.0.0:
-    dependencies:
-      split2: 4.2.0
-
   pino-abstract-transport@3.0.0:
     dependencies:
       split2: 4.2.0
@@ -10196,20 +10185,6 @@ snapshots:
       safe-stable-stringify: 2.5.0
       sonic-boom: 4.2.0
       thread-stream: 4.0.0
-
-  pino@9.14.0:
-    dependencies:
-      '@pinojs/redact': 0.4.0
-      atomic-sleep: 1.0.0
-      on-exit-leak-free: 2.1.2
-      pino-abstract-transport: 2.0.0
-      pino-std-serializers: 7.1.0
-      process-warning: 5.0.0
-      quick-format-unescaped: 4.0.4
-      real-require: 0.2.0
-      safe-stable-stringify: 2.5.0
-      sonic-boom: 4.2.0
-      thread-stream: 3.1.0
 
   pirates@4.0.7: {}
 
@@ -10968,21 +10943,6 @@ snapshots:
 
   tarn@3.0.2: {}
 
-  tedious@18.6.2:
-    dependencies:
-      '@azure/core-auth': 1.10.1
-      '@azure/identity': 4.13.0
-      '@azure/keyvault-keys': 4.10.0
-      '@js-joda/core': 5.7.0
-      '@types/node': 25.0.10
-      bl: 6.1.6
-      iconv-lite: 0.6.3
-      js-md4: 0.3.2
-      native-duplexpair: 1.0.0
-      sprintf-js: 1.1.3
-    transitivePeerDependencies:
-      - supports-color
-
   tedious@19.2.0:
     dependencies:
       '@azure/core-auth': 1.10.1
@@ -11012,10 +10972,6 @@ snapshots:
       '@istanbuljs/schema': 0.1.3
       glob: 7.2.3
       minimatch: 3.1.2
-
-  thread-stream@3.1.0:
-    dependencies:
-      real-require: 0.2.0
 
   thread-stream@4.0.0:
     dependencies:
@@ -11679,24 +11635,24 @@ snapshots:
 
   wordwrap@1.0.0: {}
 
-  workerd@1.20260124.0:
+  workerd@1.20260120.0:
     optionalDependencies:
-      '@cloudflare/workerd-darwin-64': 1.20260124.0
-      '@cloudflare/workerd-darwin-arm64': 1.20260124.0
-      '@cloudflare/workerd-linux-64': 1.20260124.0
-      '@cloudflare/workerd-linux-arm64': 1.20260124.0
-      '@cloudflare/workerd-windows-64': 1.20260124.0
+      '@cloudflare/workerd-darwin-64': 1.20260120.0
+      '@cloudflare/workerd-darwin-arm64': 1.20260120.0
+      '@cloudflare/workerd-linux-64': 1.20260120.0
+      '@cloudflare/workerd-linux-arm64': 1.20260120.0
+      '@cloudflare/workerd-windows-64': 1.20260120.0
 
-  wrangler@4.61.0:
+  wrangler@4.60.0:
     dependencies:
       '@cloudflare/kv-asset-handler': 0.4.2
-      '@cloudflare/unenv-preset': 2.11.0(unenv@2.0.0-rc.24)(workerd@1.20260124.0)
+      '@cloudflare/unenv-preset': 2.11.0(unenv@2.0.0-rc.24)(workerd@1.20260120.0)
       blake3-wasm: 2.1.5
       esbuild: 0.27.0
-      miniflare: 4.20260124.0
+      miniflare: 4.20260120.0
       path-to-regexp: 6.3.0
       unenv: 2.0.0-rc.24
-      workerd: 1.20260124.0
+      workerd: 1.20260120.0
     optionalDependencies:
       fsevents: 2.3.3
     transitivePeerDependencies:
@@ -11784,5 +11740,7 @@ snapshots:
     dependencies:
       grammex: 3.1.12
       graphmatch: 1.1.0
+
+  zod@3.25.76: {}
 
   zod@4.3.6: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -85,4 +85,4 @@ catalog:
   concurrently: 9.2.1
 
   # CLI/Docker tooling
-  wrangler: 4.14.1
+  wrangler: 4.60.0


### PR DESCRIPTION
Auto-synced from cloud repo.

**Author:** Liam
**Source:** https://github.com/ten-dev/inconvo-cloud/commit/8e3e701e23609c4c829fa34da15f75ad60ca402b

This pull request introduces support for database schemas (such as 'public' or 'sales') throughout the dev-server and agents codebases. It updates the Prisma schema and migrations, backend logic, API payloads, and agent utilities to handle and propagate schema information for tables and relations. Additionally, it includes some minor code cleanups and dependency updates.

**Database schema support:**

* Added a nullable `schema` field to the `Table` model in the Prisma schema and database, along with a migration to persist this field. [[1]](diffhunk://#diff-4f07af4bd1247f9b9ad81a784e6a0b90402166f6233671b10f84968675daea46R13) [[2]](diffhunk://#diff-3e7a35192916fdf8443935a88fc8ceb8671e572c8a07ecddefb7d168c89002fdR1-R2)
* Updated backend logic to read, write, and synchronize the `schema` field for tables, including during schema sync operations and API payloads. [[1]](diffhunk://#diff-9758a4b04b0e8b8ffce0a6e48e97279fe1dd16c51c010af9e4806fe180eb2191R59) [[2]](diffhunk://#diff-9758a4b04b0e8b8ffce0a6e48e97279fe1dd16c51c010af9e4806fe180eb2191R238) [[3]](diffhunk://#diff-9758a4b04b0e8b8ffce0a6e48e97279fe1dd16c51c010af9e4806fe180eb2191R306) [[4]](diffhunk://#diff-9758a4b04b0e8b8ffce0a6e48e97279fe1dd16c51c010af9e4806fe180eb2191L313-R327)
* Extended relation and computed column payloads to include schema information for both source and target tables. [[1]](diffhunk://#diff-9758a4b04b0e8b8ffce0a6e48e97279fe1dd16c51c010af9e4806fe180eb2191R225) [[2]](diffhunk://#diff-9758a4b04b0e8b8ffce0a6e48e97279fe1dd16c51c010af9e4806fe180eb2191L113-R116)
* Updated agent-side types, stub schemas, and query building logic to include and use table schemas. [[1]](diffhunk://#diff-0027d79995b11eb6a74ca2f34944557ae8e9bd415dcf2d2786f28d646fa67310R15) [[2]](diffhunk://#diff-6f136527dd1c19cc9255f7a0fe69eeeaa839b9e7bf59d1e88089f08ddd5174efR6) [[3]](diffhunk://#diff-6f136527dd1c19cc9255f7a0fe69eeeaa839b9e7bf59d1e88089f08ddd5174efR81) [[4]](diffhunk://#diff-6f136527dd1c19cc9255f7a0fe69eeeaa839b9e7bf59d1e88089f08ddd5174efR94) [[5]](diffhunk://#diff-6f136527dd1c19cc9255f7a0fe69eeeaa839b9e7bf59d1e88089f08ddd5174efR108) [[6]](diffhunk://#diff-6f136527dd1c19cc9255f7a0fe69eeeaa839b9e7bf59d1e88089f08ddd5174efR163) [[7]](diffhunk://#diff-8d02c76a2b956a7503ff66175ba9ce0634de6d242575839ec0151d545a788551R308)
* Improved schema stringification utilities to display schema-qualified table and relation names. [[1]](diffhunk://#diff-785a43544bec88fe1042b3be64cc34921d62977471fd70f99fffdaf916e0c3f1R36-R40) [[2]](diffhunk://#diff-785a43544bec88fe1042b3be64cc34921d62977471fd70f99fffdaf916e0c3f1L72-R81) [[3]](diffhunk://#diff-785a43544bec88fe1042b3be64cc34921d62977471fd70f99fffdaf916e0c3f1L83-R92)

**Type safety and parsing improvements:**

* Narrowed AST types for computed columns and conversions to use specific types (`SQLComputedColumnAst`, `SQLCastExpressionAst`) instead of generic objects. [[1]](diffhunk://#diff-9758a4b04b0e8b8ffce0a6e48e97279fe1dd16c51c010af9e4806fe180eb2191L178-R181) [[2]](diffhunk://#diff-9758a4b04b0e8b8ffce0a6e48e97279fe1dd16c51c010af9e4806fe180eb2191L195-R198) [[3]](diffhunk://#diff-9758a4b04b0e8b8ffce0a6e48e97279fe1dd16c51c010af9e4806fe180eb2191L676-R690) [[4]](diffhunk://#diff-9758a4b04b0e8b8ffce0a6e48e97279fe1dd16c51c010af9e4806fe180eb2191L686-R700) [[5]](diffhunk://#diff-9758a4b04b0e8b8ffce0a6e48e97279fe1dd16c51c010af9e4806fe180eb2191R6-R7)
* Improved user context parameter parsing for better type safety.

**Minor fixes and dependency updates:**

* Updated environment variable fallback logic to use nullish coalescing (`??`) for database path selection. [[1]](diffhunk://#diff-17736fca0b1729e72df3d1305a0483f24ccd2a2590ff1e90495374e60cfb83f0R6-R14) [[2]](diffhunk://#diff-bc59e1680c2af79199171ef47dd72708e32e2cf5d08fe6e7a9094dc586505a60L13-R13)
* Updated dependencies in `package.json` files to use the catalog version for consistency. [[1]](diffhunk://#diff-6043883bda6ec22a4873946dcc2160d3859b019a77d7e2bf2b6da5f1fb4047d9L27-R27) [[2]](diffhunk://#diff-6e2e2a1851648938b325ba84de634407a4e69a644ea61102df15ca4a8a7a9758L36-R36)
* Cleaned up unused interfaces and minor logic in frontend and API code. ([apps/dev-server/src/app/api/v1/agents/[agentId]/conversations/[conversation_id]/response/route.tsL17-L21](diffhunk://#diff-4d57752c11d787cab74ca0877c0d3f8fddf6c1ea71e203e481efed69fdf23e8bL17-L21), [[1]](diffhunk://#diff-2f5f3363bca12cc2df41b09bd60198d548564b961b06e40ad9c9e09029318bfeL230-L232) [[2]](diffhunk://#diff-2f5f3363bca12cc2df41b09bd60198d548564b961b06e40ad9c9e09029318bfeL310-R307)

**Agent message history filtering:**

* Improved logic for filtering out old tool and AI messages in the `inconvoAgent` to ensure all related tool call IDs are removed together.

**Temporary model override:**

* Temporarily forced the AI provider to OpenAI in the model selection utility.