### PR TITLE
feat: refactor database schema handling to support multiple schemas

### DIFF
--- a/apps/dev-server/src/env.ts
+++ b/apps/dev-server/src/env.ts
@@ -10,7 +10,12 @@ export const env = createEnv({
   server: {
     DATABASE_DIALECT: z.enum(["postgresql", "mysql", "mssql"]),
     INCONVO_DATABASE_URL: z.string().min(1),
-    INCONVO_DATABASE_SCHEMA: z.string().optional(),
+    INCONVO_DATABASE_SCHEMA: z
+      .string()
+      .optional()
+      .transform((val) =>
+        val ? val.split(",").map((s) => s.trim()).filter(Boolean) : undefined
+      ),
     INCONVO_SANDBOX_BASE_URL: z.string().url(),
     INCONVO_SANDBOX_API_KEY: z.string().min(1),
     OPENAI_API_KEY: z.string().min(1),

--- a/packages/connect/src/dbConnection.ts
+++ b/packages/connect/src/dbConnection.ts
@@ -151,16 +151,14 @@ export async function getDb(): Promise<Kysely<any>> {
     }
 
     const projectId = env.INCONVO_BIGQUERY_PROJECT_ID;
-    const dataset = env.INCONVO_BIGQUERY_DATASET ?? env.INCONVO_DATABASE_SCHEMA;
+    const dataset = env.INCONVO_BIGQUERY_DATASET;
 
     if (!projectId) {
       throw new Error("INCONVO_BIGQUERY_PROJECT_ID is required for BigQuery");
     }
 
     if (!dataset) {
-      throw new Error(
-        "INCONVO_BIGQUERY_DATASET or INCONVO_DATABASE_SCHEMA is required for BigQuery",
-      );
+      throw new Error("INCONVO_BIGQUERY_DATASET is required for BigQuery");
     }
 
     const dialectConfig: BigQueryDialectConfig = {

--- a/packages/connect/src/env.ts
+++ b/packages/connect/src/env.ts
@@ -14,7 +14,12 @@ export const env = createEnv({
   server: {
     DATABASE_DIALECT: z.enum(ALL_DIALECTS),
     INCONVO_DATABASE_URL: z.string().optional(),
-    INCONVO_DATABASE_SCHEMA: z.string().optional(),
+    INCONVO_DATABASE_SCHEMA: z
+      .string()
+      .optional()
+      .transform((val) =>
+        val ? val.split(",").map((s) => s.trim()).filter(Boolean) : undefined
+      ),
     INCONVO_SECRET_KEY: z.string(),
     NODE_ENV: z.enum(["development", "production", "test"]),
     INCONVO_BIGQUERY_PROJECT_ID: z.string().optional(),

--- a/packages/connect/src/express/index.ts
+++ b/packages/connect/src/express/index.ts
@@ -114,7 +114,7 @@ export async function inconvo(): Promise<Router> {
       );
       const publicSchema = {
         tables: sanitizedTables,
-        databaseSchema: schema.databaseSchema,
+        databaseSchemas: schema.databaseSchemas,
       };
       res.setHeader("Content-Type", "application/json");
       res.send(safeJsonStringify(publicSchema));

--- a/packages/connect/src/operations/utils/schemaHelpers.ts
+++ b/packages/connect/src/operations/utils/schemaHelpers.ts
@@ -66,9 +66,11 @@ export function getSchemaBoundDb<DB>(
   schema: SchemaResponse,
   dialect: DatabaseDialect,
 ): Kysely<DB> {
-  if (!schema.databaseSchema || dialect === "bigquery") {
+  const schemas = schema.databaseSchemas;
+  // Only use withSchema when exactly one schema is configured
+  // For multiple schemas, rely on fully-qualified table names (tableSchema on queries)
+  if (!schemas?.length || schemas.length > 1 || dialect === "bigquery") {
     return db;
   }
-
-  return db.withSchema(schema.databaseSchema);
+  return db.withSchema(schemas[0]!);
 }

--- a/packages/connect/src/types/types.d.ts
+++ b/packages/connect/src/types/types.d.ts
@@ -49,7 +49,7 @@ export interface SchemaTable {
 
 export interface SchemaResponse {
   tables: SchemaTable[];
-  databaseSchema?: string | null;
+  databaseSchemas?: string[] | null;
 }
 
 export type DatabaseDialect =

--- a/packages/connect/src/util/buildSchema.ts
+++ b/packages/connect/src/util/buildSchema.ts
@@ -36,7 +36,7 @@ export async function buildSchema(): Promise<SchemaResponse> {
 
   const config: IntrospectionConfig = {
     dialect: env.DATABASE_DIALECT,
-    databaseSchema: env.INCONVO_DATABASE_SCHEMA,
+    databaseSchemas: env.INCONVO_DATABASE_SCHEMA, // Already transformed to array by env.ts
   };
 
   // Add BigQuery-specific config if needed

--- a/packages/connect/test/mssql/multiSchema.test.ts
+++ b/packages/connect/test/mssql/multiSchema.test.ts
@@ -144,7 +144,7 @@ describe("MSSQL Multi-Schema Operations", () => {
           relations: [],
         },
       ],
-      databaseSchema: "hr",
+      databaseSchemas: ["hr"],
     };
 
     hrCtx = {

--- a/packages/connect/test/mysql/multiSchema.test.ts
+++ b/packages/connect/test/mysql/multiSchema.test.ts
@@ -144,7 +144,7 @@ describe("MySQL Multi-Schema Operations", () => {
           relations: [],
         },
       ],
-      databaseSchema: "hr",
+      databaseSchemas: ["hr"],
     };
 
     hrCtx = {

--- a/packages/connect/test/pg/multiSchema.test.ts
+++ b/packages/connect/test/pg/multiSchema.test.ts
@@ -168,7 +168,7 @@ describe("PostgreSQL Multi-Schema Operations", () => {
           relations: [],
         },
       ],
-      databaseSchema: "hr",
+      databaseSchemas: ["hr"],
     };
 
     hrCtx = {

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -44,7 +44,7 @@ const tableSchema = z
 export const SchemaResponseSchema = z
   .object({
     tables: z.array(tableSchema),
-    databaseSchema: z.string().nullable().optional(),  // Default schema for the connection
+    databaseSchemas: z.array(z.string()).nullable().optional(),  // Schema(s) to include for the connection
   })
   .strict();
 


### PR DESCRIPTION
Auto-synced from cloud repo.

**Author:** Liam
**Source:** https://github.com/ten-dev/inconvo-cloud/commit/7b9f247172b37177a6ac71925955b747ffacd519

**Files changed:**
oss/apps/dev-server/src/env.ts
oss/packages/cli/src/wizard/setup.ts
oss/packages/connect/src/dbConnection.ts
oss/packages/connect/src/env.ts
oss/packages/connect/src/express/index.ts
oss/packages/connect/src/operations/utils/schemaHelpers.ts
oss/packages/connect/src/types/types.d.ts
oss/packages/connect/src/util/buildSchema.ts
oss/packages/connect/src/util/buildSchemaFromDb.ts
oss/packages/connect/test/mssql/multiSchema.test.ts
oss/packages/connect/test/mysql/multiSchema.test.ts
oss/packages/connect/test/pg/multiSchema.test.ts
oss/packages/types/src/index.ts